### PR TITLE
Add pr-create skill for automated PR creation with CI monitoring

### DIFF
--- a/posit-dev/pr-create/SKILL.md
+++ b/posit-dev/pr-create/SKILL.md
@@ -191,8 +191,8 @@ Determine the project's local check commands by consulting (in priority order):
 3. CI workflow files in `.github/workflows/` to understand what CI will run
 
 Run the checks that are available locally. Common patterns:
-- **Lint/format**: `npm run lint`, `ruff check`, `styler::style_pkg()`, `biome check`, etc.
-- **Build**: `npm run build`, `pip install -e .`, `R CMD build`, etc.
+- **Lint/format**: `npm run lint`, `ruff check`, `air format`, `biome check`, etc.
+- **Build**: `npm run build`, `pip install -e .`, `devtools::check()`, etc.
 - **Type check**: `npm run check-types`, `mypy`, `pyright`, etc.
 - **Tests**: `npm test`, `pytest`, `devtools::test()`, `cargo test`, etc.
 


### PR DESCRIPTION
## Summary
- Adds a new `pr-create` skill that automates the PR workflow: assess state, branch, commit, sync, draft PR, run local checks, push, create PR, monitor CI, and fix failures until green
- Generalized from a project-specific workflow to be language-agnostic — discovers project check commands from CLAUDE.md/AGENTS.md, config files, and CI workflows rather than prescribing specific toolchain commands
- Assumes git, GitHub, and GitHub Actions CI; primarily targets R, Python, and web-technology projects