### PR TITLE
fix: Add missing github plugin install and fix PR thread skill arguments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,8 @@ After creating the skill directory, add it to the appropriate plugin in `.claude
 
 If a skill spans multiple categories (like `brand-yml` for both Shiny and Quarto), add its path to multiple plugin `skills` arrays. The `source` field is always `"./"` (repo root).
 
+When adding a new plugin to `marketplace.json`, also update the root `README.md` "Method 2: Direct Installation" section so it lists the `/plugin install` command for every plugin. All plugins in `marketplace.json` must have a corresponding install line in the README.
+
 ## Skill Categories
 
 | Category | Purpose |

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Install specific skill categories directly:
 
 ```
 /plugin install posit-dev@posit-dev-skills
+/plugin install github@posit-dev-skills
 /plugin install open-source@posit-dev-skills
 /plugin install r-lib@posit-dev-skills
 /plugin install shiny@posit-dev-skills

--- a/github/pr-threads-address/SKILL.md
+++ b/github/pr-threads-address/SKILL.md
@@ -110,7 +110,7 @@ EOF
 ### Resolve a Thread
 
 ```bash
-gh pr-review threads resolve --thread-id <PRRT_...> --repo <owner/repo>
+gh pr-review threads resolve --thread-id <PRRT_...> --pr <number> --repo <owner/repo>
 ```
 
 ### Start a Pending Review

--- a/github/pr-threads-resolve/SKILL.md
+++ b/github/pr-threads-resolve/SKILL.md
@@ -87,10 +87,10 @@ Toggle thread resolution status:
 
 ```bash
 # Resolve a thread
-gh pr-review threads resolve --thread-id <PRRT_...> --repo <owner/repo>
+gh pr-review threads resolve --thread-id <PRRT_...> --pr <number> --repo <owner/repo>
 
 # Unresolve a thread
-gh pr-review threads unresolve --thread-id <PRRT_...> --repo <owner/repo>
+gh pr-review threads unresolve --thread-id <PRRT_...> --pr <number> --repo <owner/repo>
 ```
 
 ### Bulk Resolve Example
@@ -99,7 +99,7 @@ gh pr-review threads unresolve --thread-id <PRRT_...> --repo <owner/repo>
 # Get all unresolved thread IDs and resolve them
 gh pr-review threads list --pr 42 --unresolved --repo owner/repo | \
   jq -r '.threads[].id' | \
-  xargs -I {} gh pr-review threads resolve --thread-id {} --repo owner/repo
+  xargs -I {} gh pr-review threads resolve --thread-id {} --pr 42 --repo owner/repo
 ```
 
 ## Usage Notes


### PR DESCRIPTION
Ensure all skill marketplaces can be installed and fix missing --pr argument in gh-pr-review commands.

**Changes:**
- Add missing `/plugin install github@posit-dev-skills` command to README installation instructions (Method 2)
- Add developer guidance in CLAUDE.md to keep marketplace.json and README installation instructions in sync
- Fix `gh pr-review threads resolve` and `threads unresolve` commands to include required `--pr <number>` argument in both pr-threads-resolve and pr-threads-address skills
- Fix bulk resolve example in pr-threads-resolve to pass PR number to each resolve command

**Verification:**
Users can now follow all listed `/plugin install` commands without failures due to missing --pr arguments.