### PR TITLE
feat(quarto): add quarto-lua skill for Lua shortcodes and filters

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -74,7 +74,8 @@
       "skills": [
         "./brand-yml",
         "./quarto/quarto-authoring",
-        "./quarto/quarto-alt-text"
+        "./quarto/quarto-alt-text",
+        "./quarto/quarto-lua"
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Skills for Quarto document creation and publishing.
 - **[brand-yml](./brand-yml/)** - Create and apply brand.yml files for consistent styling across Quarto projects, supporting HTML documents, dashboards, RevealJS presentations, Typst PDFs, and websites with automatic brand discovery and theme layering
 - **[authoring](quarto/README.md#quarto-authoring-skill)** - Comprehensive guidance for Quarto document authoring and R Markdown migration. Write new Quarto documents with best practices, convert R Markdown files, migrate bookdown/blogdown/xaringan/distill projects, and use Quarto-specific features like hashpipe syntax, cross-references, callouts, and extensions
 - **[quarto-alt-text](./quarto/quarto-alt-text/)** - Generate accessible alt text for figures in Quarto documents using Amy Cesal's three-part formula (chart type, data description, key insight). Supports code-generated plots and static images
+- **[quarto-lua](./quarto/quarto-lua/)** - Write Lua shortcodes and filters for Quarto, with runtime access to Quarto's LLM-optimised API documentation
 
 ## Installation
 

--- a/quarto/README.md
+++ b/quarto/README.md
@@ -76,10 +76,11 @@ Comprehensive guidance for Quarto document authoring and R Markdown migration. W
 Create and use `_brand.yml` files for consistent branding across Quarto documents and Shiny applications. Use when working with brand styling, corporate identity, colors, fonts, or logos in Quarto projects.
 
 **Organization**: Main skill file includes workflows and decision tree. Reference files provide framework-specific integration guides:
-- `brand-yml-spec.md` - Complete brand.yml specification
-- `shiny-r.md` - Shiny for R integration with bslib
-- `shiny-python.md` - Shiny for Python integration with ui.Theme
-- `quarto.md` - Quarto integration for all formats (HTML, dashboards, RevealJS presentations, Typst PDFs, websites)
+
+- `brand-yml-spec.md` - Complete brand.yml specification.
+- `shiny-r.md` - Shiny for R integration with bslib.
+- `shiny-python.md` - Shiny for Python integration with ui.Theme.
+- `quarto.md` - Quarto integration for all formats (HTML, dashboards, RevealJS presentations, Typst PDFs, websites).
 
 **Note**: This skill is also registered in the shiny category since brand.yml works across both Shiny and Quarto projects.
 
@@ -89,6 +90,16 @@ Create and use `_brand.yml` files for consistent branding across Quarto document
 - [Quarto brand.yml docs](https://quarto.org/docs/authoring/brand.html)
 - [Shiny for R brand.yml guide](https://rstudio.github.io/bslib/articles/brand-yml/)
 - [Shiny for Python brand.yml docs](https://shiny.posit.co/py/api/core/ui.Theme.html#shiny.ui.Theme.from_brand)
+
+---
+
+### `lua`
+
+Write Lua shortcodes and filters for Quarto. Covers shortcode handlers, Pandoc AST filters, Lua coding conventions, Quarto-specific Lua APIs, and common patterns. Includes runtime access to Quarto's LLM-optimised documentation (`.llms.md` pages) for detailed API reference.
+
+#### Authors
+
+- [Mickaël CANOUIL](https://github.com/mcanouil)
 
 ---
 
@@ -106,13 +117,12 @@ Generate accessible alt text for data visualizations in Quarto documents. Use wh
 
 This category could include skills for:
 
-- Publishing workflows
-- Extension development
-- Template creation
-- Multi-format output
-- Parameterized reports
-- Website and book publishing
-- Presentation design
+- Publishing workflows.
+- Template creation.
+- Multi-format output.
+- Parameterized reports.
+- Website and book publishing.
+- Presentation design.
 
 ## Contributing
 

--- a/quarto/README.md
+++ b/quarto/README.md
@@ -93,7 +93,7 @@ Create and use `_brand.yml` files for consistent branding across Quarto document
 
 ---
 
-### `lua`
+### `quarto-lua`
 
 Write Lua shortcodes and filters for Quarto. Covers shortcode handlers, Pandoc AST filters, Lua coding conventions, Quarto-specific Lua APIs, and common patterns. Includes runtime access to Quarto's LLM-optimised documentation (`.llms.md` pages) for detailed API reference.
 

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -15,7 +15,7 @@ license: MIT
 
 Write Lua shortcodes and filters for Quarto.
 
-> This skill is based on Quarto CLI v1.8.26.
+> This skill is based on Quarto CLI v1.9.30.
 
 ## When to Use What
 

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -28,8 +28,6 @@ Task: Filter details (AST traversal, multi-pass) -> WebFetch `https://quarto.org
 Task: Metadata / project filters -> WebFetch `https://quarto.org/docs/extensions/metadata.llms.md`
 
 Fetch only pages relevant to the current task.
-The fetched `.llms.md` pages may contain `.llms.md` URLs for external sites (e.g., `lua.org`, `pandoc.org`).
-These are broken links. Only `https://quarto.org` URLs have valid `.llms.md` pages; replace with `.html` for any other domain.
 
 ## Writing a Shortcode
 

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -26,6 +26,7 @@ Task: Debug Lua / tooling -> WebFetch `https://quarto.org/docs/extensions/lua.ll
 Task: Shortcode details (args, raw output) -> WebFetch `https://quarto.org/docs/extensions/shortcodes.llms.md`
 Task: Filter details (AST traversal, multi-pass) -> WebFetch `https://quarto.org/docs/extensions/filters.llms.md`
 Task: Metadata / project filters -> WebFetch `https://quarto.org/docs/extensions/metadata.llms.md`
+Task: Custom AST nodes / filter timing -> Read `references/custom-ast-nodes.md` in this skill directory
 
 Fetch only pages relevant to the current task.
 
@@ -153,6 +154,24 @@ Quarto resolves `require` paths relative to the calling script's directory.
 ```bash
 quarto render example.qmd
 ```
+
+## Custom AST Nodes
+
+Quarto extends Pandoc's AST with custom node types that filters can match by name.
+
+**Block-level:** Callout, ConditionalBlock, Tabset, PanelLayout, FloatRefTarget, DecoratedCodeBlock, Theorem, Proof.
+
+**Inline-level:** Shortcode.
+
+**Other:** LatexEnvironment, LatexInlineCommand, HtmlTag.
+
+Constructors exist for: `quarto.Callout(tbl)`, `quarto.ConditionalBlock(tbl)`, `quarto.Tabset(tbl)`, `quarto.Tab(tbl)`.
+
+Cross-referenceable elements (figures, tables, listings) are represented as `FloatRefTarget` nodes.
+
+Filter timing supports eight phases (`pre-ast` through `post-finalize`) via the `at` property in `_extension.yml`.
+
+For full constructor signatures and filter timing details, read `references/custom-ast-nodes.md`.
 
 ## Resources
 

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -15,7 +15,7 @@ license: MIT
 
 Write Lua shortcodes and filters for Quarto.
 
-> This skill is based on Quarto CLI v1.9.30.
+> This skill is based on Quarto CLI v1.9.30 (2026-03-09).
 
 ## When to Use What
 

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: quarto-lua
+description: >
+  Write Lua shortcodes and filters for Quarto.
+  Use when creating, debugging, or modifying Lua code that runs inside
+  Quarto, including shortcode handlers, Quarto Lua filters, and
+  Quarto-specific Lua APIs.
+metadata:
+  author: Mickaël Canouil (@mcanouil)
+  version: "1.0"
+license: MIT
+---
+
+# Quarto Lua
+
+Write Lua shortcodes and filters for Quarto.
+
+> This skill is based on Quarto CLI v1.8.26.
+
+## When to Use What
+
+Task: Write a shortcode -> "Writing a Shortcode" below
+Task: Write a filter -> "Writing a Filter" below
+Task: Pandoc Lua API (constructors, types, methods) -> WebFetch `https://quarto.org/docs/extensions/lua-api.llms.md`
+Task: Debug Lua / tooling -> WebFetch `https://quarto.org/docs/extensions/lua.llms.md`
+Task: Shortcode details (args, raw output) -> WebFetch `https://quarto.org/docs/extensions/shortcodes.llms.md`
+Task: Filter details (AST traversal, multi-pass) -> WebFetch `https://quarto.org/docs/extensions/filters.llms.md`
+Task: Metadata / project filters -> WebFetch `https://quarto.org/docs/extensions/metadata.llms.md`
+
+Fetch only pages relevant to the current task.
+The fetched `.llms.md` pages may contain `.llms.md` URLs for external sites (e.g., `lua.org`, `pandoc.org`).
+These are broken links. Only `https://quarto.org` URLs have valid `.llms.md` pages; replace with `.html` for any other domain.
+
+## Writing a Shortcode
+
+A shortcode exports a function called whenever `{{< name ... >}}` appears in `.qmd`.
+Register under `shortcodes:` in `_extension.yml` or document YAML.
+Add a file header (see "Lua File Header Convention"), then:
+
+```lua
+return function(args, kwargs, meta, raw_args)
+  local name = pandoc.utils.stringify(args[1] or "world")
+  return pandoc.Str("Hello, " .. name .. "!")
+end
+```
+
+Parameters: `args` (positional, 1-indexed), `kwargs` (named), `meta` (document metadata), `raw_args` (unparsed strings).
+Both `args` and `kwargs` contain `pandoc.Inlines`; use `pandoc.utils.stringify()` to get strings.
+Return `pandoc.Inlines` or `pandoc.Blocks`. Use `pandoc.RawInline`/`pandoc.RawBlock` for format-specific output.
+Verify the exact handler signature against the shortcodes `.llms.md` page when targeting a specific Quarto version.
+
+## Writing a Filter
+
+A filter returns a list of handler tables mapping AST element types to transform functions.
+Register under `filters:` in `_extension.yml` or document YAML.
+Add a file header (see "Lua File Header Convention"), then:
+
+```lua
+local function convert_emph(el)
+  return pandoc.SmallCaps(el.content)
+end
+
+return {
+  { Emph = convert_emph }
+}
+```
+
+Each table is a separate traversal pass. Handlers return a replacement element, a list, or `nil` (or nothing) to skip.
+Use a `Pandoc(doc)` handler to process the entire document, or `Meta(meta)` to read/modify metadata.
+Multiple passes: `return { { Header = fix_headers }, { Link = fix_links } }`.
+
+## Lua File Header Convention
+
+Every `.lua` file must start with:
+
+```lua
+--- name - Short description
+--- @module name.lua
+--- @license MIT
+--- @copyright 2026 Author Name
+--- @author Author Name
+--- @version 0.1.0
+--- @brief One-line summary.
+--- @description Longer explanation of purpose and behaviour.
+---   Wrap at ~72 chars, indent continuation with two spaces.
+```
+
+Fields: `@module` (filename), `@license`, `@copyright`, `@author`, `@version` (semver), `@brief` (one-liner), `@description` (multi-line).
+Always generate for new files. Update `@version`/`@description` when modifying.
+
+## Lua Style and Conventions
+
+- **Naming**: `snake_case` for variables/functions, `PascalCase` for module-level tables only.
+- **Indentation**: 2 spaces.
+- **Strings**: double quotes for user-facing text, single quotes for identifiers/keys.
+- **Scoping**: always `local` unless intentionally global.
+- **Errors**: fail fast with `error("context: what went wrong")`.
+- **Docs**: `---` comment blocks above functions (LDoc-compatible):
+
+```lua
+--- Convert a Pandoc inline element to plain text.
+--- @param el pandoc.Inline The inline element to convert.
+--- @return string The plain text representation.
+local function stringify_inline(el)
+  return pandoc.utils.stringify(el)
+end
+```
+
+## Common Patterns
+
+### `pandoc.utils.stringify()`
+
+Converts any AST element to plain text. Use for shortcode arguments and metadata fields.
+
+### Format Detection
+
+Check the output format before emitting format-specific content:
+
+```lua
+if quarto.doc.is_format("html") then
+  -- HTML-only logic
+end
+```
+
+### Quarto Document APIs
+
+```lua
+-- HTML only; no-op for PDF/Typst
+quarto.doc.add_html_dependency({
+  name = "my-dep", version = "0.1.0",
+  stylesheets = { "style.css" }, scripts = { "script.js" }
+})
+
+-- Works for all formats (HTML, LaTeX/PDF, Typst)
+quarto.doc.include_text("in-header", "...")
+-- Positions: "in-header", "before-body", "after-body"
+```
+
+### Debugging
+
+```lua
+quarto.log.output("my-var:", my_var)
+```
+
+### Multi-file Modules
+
+```lua
+local utils = require("utils")
+```
+
+Quarto resolves `require` paths relative to the calling script's directory.
+
+### Testing
+
+```bash
+quarto render example.qmd
+```
+
+## Resources
+
+- [Quarto Lua API](https://quarto.org/docs/extensions/lua-api.html)
+- [Pandoc Lua Filters reference](https://pandoc.org/lua-filters.html)
+- [Pandoc community Lua filters](https://github.com/pandoc/lua-filters)
+- [LuaRocks style guide](https://github.com/luarocks/lua-style-guide)

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quarto-lua
-description: Write Lua shortcodes and filters for Quarto. Use when creating, debugging, or modifying Lua code that runs inside Quarto, including shortcode handlers, Quarto Lua filters, and Quarto-specific Lua APIs.
+description: "Write Lua shortcodes and filters for Quarto. TRIGGER when: code involves `.lua` files in a Quarto project, `_extension.yml` manifests, Pandoc Lua filters, shortcode handlers, `quarto.doc.*` or `quarto.log.*` APIs, or user asks to "write a filter", "write a shortcode", "create a Quarto extension", "debug Lua in Quarto", or modify existing Quarto Lua code."
 metadata:
   author: Mickaël Canouil (@mcanouil)
   version: "1.0"

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -26,7 +26,7 @@ Task: Debug Lua / tooling -> Read `https://quarto.org/docs/extensions/lua.llms.m
 Task: Shortcode details (args, raw output) -> Read `https://quarto.org/docs/extensions/shortcodes.llms.md`
 Task: Filter details (AST traversal, multi-pass) -> Read `https://quarto.org/docs/extensions/filters.llms.md`
 Task: Metadata / project filters -> Read `https://quarto.org/docs/extensions/metadata.llms.md`
-Task: Custom AST nodes / filter timing -> Read the file `references/custom-ast-nodes.md` in this skill directory
+Task: Custom AST nodes (callout, conditional block, tabset, panel layout, cross-reference, decorated code block, theorem, proof) / filter timing -> Read the file `references/custom-ast-nodes.md` in this skill directory
 
 Fetch only pages relevant to the current task.
 

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quarto-lua
-description: "Write Lua shortcodes and filters for Quarto. TRIGGER when: code involves `.lua` files in a Quarto project, `_extension.yml` manifests, Pandoc Lua filters, shortcode handlers, `quarto.doc.*` or `quarto.log.*` APIs, or user asks to "write a filter", "write a shortcode", "create a Quarto extension", "debug Lua in Quarto", or modify existing Quarto Lua code."
+description: 'Write Lua shortcodes and filters for Quarto. TRIGGER when: code involves `.lua` files in a Quarto project, `_extension.yml` manifests, Pandoc Lua filters, shortcode handlers, `quarto.doc.*` or `quarto.log.*` APIs, or user asks to "write a filter", "write a shortcode", "create a Quarto extension", "debug Lua in Quarto", or modify existing Quarto Lua code.'
 metadata:
   author: Mickaël Canouil (@mcanouil)
   version: "1.0"

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -11,6 +11,8 @@ license: MIT
 
 Write Lua shortcodes and filters for Quarto.
 
+**Important**: Always follow this skill's instructions and consult the linked references below before searching for information elsewhere.
+
 > This skill is based on Quarto CLI v1.9.36 (2026-03-24).
 
 ## When to Use What

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -15,7 +15,7 @@ license: MIT
 
 Write Lua shortcodes and filters for Quarto.
 
-> This skill is based on Quarto CLI v1.9.30 (2026-03-09).
+> This skill is based on Quarto CLI v1.9.36 (2026-03-24).
 
 ## When to Use What
 

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -19,11 +19,11 @@ Write Lua shortcodes and filters for Quarto.
 
 Task: Write a shortcode -> "Writing a Shortcode" below
 Task: Write a filter -> "Writing a Filter" below
-Task: Pandoc Lua API (constructors, types, methods) -> Fetch `https://quarto.org/docs/extensions/lua-api.llms.md`
-Task: Debug Lua / tooling -> Fetch `https://quarto.org/docs/extensions/lua.llms.md`
-Task: Shortcode details (args, raw output) -> Fetch `https://quarto.org/docs/extensions/shortcodes.llms.md`
-Task: Filter details (AST traversal, multi-pass) -> Fetch `https://quarto.org/docs/extensions/filters.llms.md`
-Task: Metadata / project filters -> Fetch `https://quarto.org/docs/extensions/metadata.llms.md`
+Task: Quarto and Pandoc Lua API (constructors, types, methods) -> Read `https://quarto.org/docs/extensions/lua-api.llms.md`
+Task: Debug Lua / tooling -> Read `https://quarto.org/docs/extensions/lua.llms.md`
+Task: Shortcode details (args, raw output) -> Read `https://quarto.org/docs/extensions/shortcodes.llms.md`
+Task: Filter details (AST traversal, multi-pass) -> Read `https://quarto.org/docs/extensions/filters.llms.md`
+Task: Metadata / project filters -> Read `https://quarto.org/docs/extensions/metadata.llms.md`
 Task: Custom AST nodes / filter timing -> Read the file `references/custom-ast-nodes.md` in this skill directory
 
 Fetch only pages relevant to the current task.

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -19,12 +19,12 @@ Write Lua shortcodes and filters for Quarto.
 
 Task: Write a shortcode -> "Writing a Shortcode" below
 Task: Write a filter -> "Writing a Filter" below
-Task: Pandoc Lua API (constructors, types, methods) -> WebFetch `https://quarto.org/docs/extensions/lua-api.llms.md`
-Task: Debug Lua / tooling -> WebFetch `https://quarto.org/docs/extensions/lua.llms.md`
-Task: Shortcode details (args, raw output) -> WebFetch `https://quarto.org/docs/extensions/shortcodes.llms.md`
-Task: Filter details (AST traversal, multi-pass) -> WebFetch `https://quarto.org/docs/extensions/filters.llms.md`
-Task: Metadata / project filters -> WebFetch `https://quarto.org/docs/extensions/metadata.llms.md`
-Task: Custom AST nodes / filter timing -> Read `references/custom-ast-nodes.md` in this skill directory
+Task: Pandoc Lua API (constructors, types, methods) -> Fetch `https://quarto.org/docs/extensions/lua-api.llms.md`
+Task: Debug Lua / tooling -> Fetch `https://quarto.org/docs/extensions/lua.llms.md`
+Task: Shortcode details (args, raw output) -> Fetch `https://quarto.org/docs/extensions/shortcodes.llms.md`
+Task: Filter details (AST traversal, multi-pass) -> Fetch `https://quarto.org/docs/extensions/filters.llms.md`
+Task: Metadata / project filters -> Fetch `https://quarto.org/docs/extensions/metadata.llms.md`
+Task: Custom AST nodes / filter timing -> Read the file `references/custom-ast-nodes.md` in this skill directory
 
 Fetch only pages relevant to the current task.
 

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -33,7 +33,13 @@ Fetch only pages relevant to the current task.
 ## Writing a Shortcode
 
 A shortcode exports a function called whenever `{{< name ... >}}` appears in `.qmd`.
-Register under `shortcodes:` in `_extension.yml` or document YAML.
+Register under `shortcodes:` in the document YAML header or projec YAML (`_quarto.yml`).
+
+```yaml
+shortcodes:
+  - my-shortcode.lua
+```
+
 Add a file header (see "Lua File Header Convention"), then:
 
 ```lua
@@ -51,7 +57,13 @@ Verify the exact handler signature against the shortcodes `.llms.md` page when t
 ## Writing a Filter
 
 A filter returns a list of handler tables mapping AST element types to transform functions.
-Register under `filters:` in `_extension.yml` or document YAML.
+Register under `filters:` in the document YAML header or projec YAML (`_quarto.yml`).
+
+```yaml
+filters:
+  - my-filter.lua
+```
+
 Add a file header (see "Lua File Header Convention"), then:
 
 ```lua

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -33,7 +33,7 @@ Fetch only pages relevant to the current task.
 ## Writing a Shortcode
 
 A shortcode exports a function called whenever `{{< name ... >}}` appears in `.qmd`.
-Register under `shortcodes:` in the document YAML header or projec YAML (`_quarto.yml`).
+Register under `shortcodes:` in the document YAML header or project YAML (`_quarto.yml`).
 
 ```yaml
 shortcodes:
@@ -57,7 +57,7 @@ Verify the exact handler signature against the shortcodes `.llms.md` page when t
 ## Writing a Filter
 
 A filter returns a list of handler tables mapping AST element types to transform functions.
-Register under `filters:` in the document YAML header or projec YAML (`_quarto.yml`).
+Register under `filters:` in the document YAML header or project YAML (`_quarto.yml`).
 
 ```yaml
 filters:

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -87,17 +87,13 @@ Every `.lua` file must start with:
 ```lua
 --- name - Short description
 --- @module name.lua
---- @license MIT
---- @copyright 2026 Author Name
 --- @author Author Name
---- @version 0.1.0
---- @brief One-line summary.
 --- @description Longer explanation of purpose and behaviour.
 ---   Wrap at ~72 chars, indent continuation with two spaces.
 ```
 
-Fields: `@module` (filename), `@license`, `@copyright`, `@author`, `@version` (semver), `@brief` (one-liner), `@description` (multi-line).
-Always generate for new files. Update `@version`/`@description` when modifying.
+Fields: `@module` (filename), `@author`, and `@description` (multi-line).
+Always generate for new files. Update `@description` when modifying.
 
 ## Lua Style and Conventions
 

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: quarto-lua
-description: >
-  Write Lua shortcodes and filters for Quarto.
-  Use when creating, debugging, or modifying Lua code that runs inside
-  Quarto, including shortcode handlers, Quarto Lua filters, and
-  Quarto-specific Lua APIs.
+description: Write Lua shortcodes and filters for Quarto. Use when creating, debugging, or modifying Lua code that runs inside Quarto, including shortcode handlers, Quarto Lua filters, and Quarto-specific Lua APIs.
 metadata:
   author: Mickaël Canouil (@mcanouil)
   version: "1.0"
@@ -19,6 +15,8 @@ Write Lua shortcodes and filters for Quarto.
 
 ## When to Use What
 
+**First question**: When asked to create a new shortcode or filter, ask the user whether it should be a standalone file (registered in `_quarto.yml` or document YAML) or packaged as a Quarto extension (with `_extension.yml`).
+
 Task: Write a shortcode -> "Writing a Shortcode" below
 Task: Write a filter -> "Writing a Filter" below
 Task: Pandoc Lua API (constructors, types, methods) -> WebFetch `https://quarto.org/docs/extensions/lua-api.llms.md`
@@ -30,6 +28,34 @@ Task: Custom AST nodes / filter timing -> Read `references/custom-ast-nodes.md` 
 
 Fetch only pages relevant to the current task.
 
+## Quarto Extension Structure
+
+A Quarto extension lives in `_extensions/<name>/` with an `_extension.yml` manifest and one or more `.lua` files alongside it.
+
+```
+_extensions/
+  my-extension/
+    _extension.yml
+    my-extension.lua
+```
+
+Extension manifest (`_extension.yml`):
+
+```yaml
+title: My Extension
+author: Firstname Lastname
+version: X.Y.Z
+quarto-required: ">=1.6.0"
+contributes:
+  shortcodes:          # for shortcode extensions
+    - my-shortcode.lua
+  filters:             # for filter extensions
+    - my-filter.lua
+```
+
+Fields: `title` (display name), `author`, `version` (semver), `quarto-required` (optional minimum Quarto version), `contributes` (what the extension provides).
+List only the relevant key under `contributes` (shortcodes, filters, or both).
+
 ## Writing a Shortcode
 
 A shortcode exports a function called whenever `{{< name ... >}}` appears in `.qmd`.
@@ -39,6 +65,8 @@ Register under `shortcodes:` in the document YAML header or project YAML (`_quar
 shortcodes:
   - my-shortcode.lua
 ```
+
+For extension packaging, register in `_extension.yml` instead (see "Quarto Extension Structure" above).
 
 Add a file header (see "Lua File Header Convention"), then:
 
@@ -63,6 +91,8 @@ Register under `filters:` in the document YAML header or project YAML (`_quarto.
 filters:
   - my-filter.lua
 ```
+
+For extension packaging, register in `_extension.yml` instead (see "Quarto Extension Structure" above).
 
 Add a file header (see "Lua File Header Convention"), then:
 
@@ -183,7 +213,7 @@ For full constructor signatures and filter timing details, read `references/cust
 
 ## Resources
 
-- [Quarto Lua API](https://quarto.org/docs/extensions/lua-api.html)
+- [Quarto Lua API](https://quarto.org/docs/extensions/lua-api.llms.md)
 - [Pandoc Lua Filters reference](https://pandoc.org/lua-filters.html)
 - [Pandoc community Lua filters](https://github.com/pandoc/lua-filters)
 - [LuaRocks style guide](https://github.com/luarocks/lua-style-guide)

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -231,10 +231,6 @@ If two filters each ship a `utils.lua`, the second filter silently receives the 
 This happens across separate installed extensions as well.
 There is no error, only a wrong result.
 
-Inside an extension, keep every module path within the extension directory.
-`quarto add` copies only `_extensions/<name>/`, so a `require("../shared")` that works in the source project stops the render after installation with `cannot open .../_extensions/shared.lua`.
-Put shared code in a subdirectory of the extension instead.
-
 ### Testing
 
 ```bash

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -17,7 +17,10 @@ Write Lua shortcodes and filters for Quarto.
 
 ## When to Use What
 
-**First question**: When asked to create a new shortcode or filter, ask the user whether it should be a standalone file (registered in `_quarto.yml` or document YAML) or packaged as a Quarto extension (with `_extension.yml`).
+**First question**: A new shortcode or filter is either a standalone file, registered in `_quarto.yml` or document YAML, or packaged as a Quarto extension with `_extension.yml`.
+Infer which one from the context before asking.
+An `_extensions/<name>/_extension.yml` beside the target path, or a path already inside `_extensions/`, settles it.
+Ask the user only when the context gives no answer, and assume a standalone file when you cannot ask.
 
 Task: Write a shortcode -> "Writing a Shortcode" below
 Task: Write a filter -> "Writing a Filter" below
@@ -27,7 +30,7 @@ Task: Shortcode details (args, raw output) -> Read `https://quarto.org/docs/exte
 Task: Filter details (AST traversal, multi-pass) -> Read `https://quarto.org/docs/extensions/filters.llms.md`
 Task: Metadata / project filters -> Read `https://quarto.org/docs/extensions/metadata.llms.md`
 Task: Custom AST node fields, custom renderers, AST processing phases -> Read `https://quarto.org/docs/advanced/quarto-ast.llms.md`
-Task: Custom AST node constructor signatures, full node type list, all eight filter timing phases -> Read the file `references/custom-ast-nodes.md` in this skill directory
+Task: Custom AST node constructor signatures, all eight filter timing phases -> Read the file `references/custom-ast-nodes.md` in this skill directory
 
 Fetch only pages relevant to the current task.
 Prefer `references/custom-ast-nodes.md` over the Quarto AST page for constructor signatures and timing phases.
@@ -155,7 +158,7 @@ Always generate for new files. Update `@description` when modifying.
 
 - **Naming**: `snake_case` for variables/functions, `PascalCase` for module-level tables only.
 - **Indentation**: 2 spaces.
-- **Strings**: double quotes for user-facing text, single quotes for identifiers/keys.
+- **Strings**: double quotes throughout, as in Quarto's own filter sources.
 - **Scoping**: always `local` unless intentionally global.
 - **Errors**: fail fast with `error("context: what went wrong")`.
 - **Docs**: `---` comment blocks above functions (LDoc-compatible):
@@ -271,7 +274,7 @@ Cross-referenceable figures, tables, and listings are all `FloatRefTarget` nodes
 
 Filter timing supports eight phases, `pre-ast` through `post-finalize`, set with the `at` property in `_extension.yml` or document YAML.
 
-For the full node type list, constructor signatures, and timing phases, read `references/custom-ast-nodes.md`.
+For constructor signatures and timing phases, read `references/custom-ast-nodes.md`.
 
 ## Resources
 

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -214,15 +214,26 @@ local parsing = require("./sub/parsing")
 
 Quarto replaces the standard Lua `require()` so that a path that starts with `./` or `../` resolves relative to the calling script.
 Always use the relative form.
+It resolves against the file that calls it, so it also works inside a module that another module requires.
+
+A bare name does not work inside a module.
+Quarto puts only the directory of the top-level filter or shortcode file on `package.path`, so a module cannot load a file beside it by bare name.
+The render stops with `module 'b' not found`.
+
+```lua
+-- _modules/a.lua
+local b = require("b")    -- fails
+local b = require("./b")  -- correct
+```
+
+A bare name called from the top-level file does load, but the module name is then global to the render.
+If two filters each ship a `utils.lua`, the second filter silently receives the module of the first one.
+This happens across separate installed extensions as well.
+There is no error, only a wrong result.
 
 Inside an extension, keep every module path within the extension directory.
 `quarto add` copies only `_extensions/<name>/`, so a `require("../shared")` that works in the source project stops the render after installation with `cannot open .../_extensions/shared.lua`.
 Put shared code in a subdirectory of the extension instead.
-
-A bare `require("utils")` still loads, but the module name is global to the render.
-If two filters each ship a `utils.lua`, the second filter silently receives the module of the first one.
-This happens across separate installed extensions as well.
-There is no error, only a wrong result.
 
 ### Testing
 

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quarto-lua
-description: 'Write Lua shortcodes and filters for Quarto. TRIGGER when: code involves `.lua` files in a Quarto project, `_extension.yml` manifests, Pandoc Lua filters, shortcode handlers, `quarto.doc.*` or `quarto.log.*` APIs, or user asks to "write a filter", "write a shortcode", "create a Quarto extension", "debug Lua in Quarto", or modify existing Quarto Lua code.'
+description: 'Write Lua shortcodes and filters for Quarto. TRIGGER when: code involves `.lua` files in a Quarto project, `_extension.yml` manifests, Pandoc Lua filters, shortcode handlers, `quarto.*` Lua APIs, or user asks to "write a filter", "write a shortcode", "create a Quarto extension", "debug Lua in Quarto", or modify existing Quarto Lua code.'
 metadata:
   author: Mickaël Canouil (@mcanouil)
   version: "1.0"
@@ -13,7 +13,7 @@ Write Lua shortcodes and filters for Quarto.
 
 **Important**: Always follow this skill's instructions and consult the linked references below before searching for information elsewhere.
 
-> This skill is based on Quarto CLI v1.9.36 (2026-03-24).
+> This skill is based on Quarto CLI v1.10.18 (2026-08-25).
 
 ## When to Use What
 
@@ -26,15 +26,18 @@ Task: Debug Lua / tooling -> Read `https://quarto.org/docs/extensions/lua.llms.m
 Task: Shortcode details (args, raw output) -> Read `https://quarto.org/docs/extensions/shortcodes.llms.md`
 Task: Filter details (AST traversal, multi-pass) -> Read `https://quarto.org/docs/extensions/filters.llms.md`
 Task: Metadata / project filters -> Read `https://quarto.org/docs/extensions/metadata.llms.md`
-Task: Custom AST nodes (callout, conditional block, tabset, panel layout, cross-reference, decorated code block, theorem, proof) / filter timing -> Read the file `references/custom-ast-nodes.md` in this skill directory
+Task: Custom AST node fields, custom renderers, AST processing phases -> Read `https://quarto.org/docs/advanced/quarto-ast.llms.md`
+Task: Custom AST node constructor signatures, full node type list, all eight filter timing phases -> Read the file `references/custom-ast-nodes.md` in this skill directory
 
 Fetch only pages relevant to the current task.
+Prefer `references/custom-ast-nodes.md` over the Quarto AST page for constructor signatures and timing phases.
+The Quarto AST page omits `pre-finalize` and `post-finalize`, and the constructor table is missing from the `lua-api.llms.md` page.
 
 ## Quarto Extension Structure
 
 A Quarto extension lives in `_extensions/<name>/` with an `_extension.yml` manifest and one or more `.lua` files alongside it.
 
-```
+```text
 _extensions/
   my-extension/
     _extension.yml
@@ -47,7 +50,7 @@ Extension manifest (`_extension.yml`):
 title: My Extension
 author: Firstname Lastname
 version: X.Y.Z
-quarto-required: ">=1.6.0"
+quarto-required: ">=1.10.0"
 contributes:
   shortcodes:          # for shortcode extensions
     - my-shortcode.lua
@@ -60,29 +63,44 @@ List only the relevant key under `contributes` (shortcodes, filters, or both).
 
 ## Writing a Shortcode
 
-A shortcode exports a function called whenever `{{< name ... >}}` appears in `.qmd`.
-Register under `shortcodes:` in the document YAML header or project YAML (`_quarto.yml`).
+A shortcode file returns a table that maps shortcode names to handler functions.
+The table key is the name used in `{{< name ... >}}`, not the file name.
+Register the file under `shortcodes:` in the document YAML header or project YAML (`_quarto.yml`).
 
 ```yaml
 shortcodes:
   - my-shortcode.lua
 ```
 
-For extension packaging, register in `_extension.yml` instead (see "Quarto Extension Structure" above).
+For extension packaging, list the file under `contributes.shortcodes` in `_extension.yml` instead (see "Quarto Extension Structure" above).
+An installed shortcode extension is then active with no YAML key in the document.
 
 Add a file header (see "Lua File Header Convention"), then:
 
 ```lua
-return function(args, kwargs, meta, raw_args)
-  local name = pandoc.utils.stringify(args[1] or "world")
-  return pandoc.Str("Hello, " .. name .. "!")
-end
+return {
+  ["hello"] = function(args, kwargs, meta, raw_args)
+    local name = quarto.shortcode.read_arg(args)
+    if name == nil then
+      return quarto.shortcode.error_output("hello", "missing name argument", "inline")
+    end
+    return pandoc.Str("Hello, " .. name .. "!")
+  end
+}
 ```
+
+This handler runs for `{{< hello Bob >}}`.
+Add more keys to the same table to export several shortcodes from one file.
+
+Never return a bare function from a shortcode file.
+Quarto iterates the returned value with `pairs()`, so a function fails the render with `bad argument #1 to 'for iterator' (table expected, got function)`.
+A file that returns nothing also works, because Quarto then collects the global functions the file defines, but the table form is explicit and is what to generate.
 
 Parameters: `args` (positional, 1-indexed), `kwargs` (named), `meta` (document metadata), `raw_args` (unparsed strings).
 Both `args` and `kwargs` contain `pandoc.Inlines`; use `pandoc.utils.stringify()` to get strings.
+`quarto.shortcode.read_arg(args, n)` is the shorthand: it reads the `n`-th argument as a string and returns `nil` when the argument is absent, with `n` defaulting to `1`.
 Return `pandoc.Inlines` or `pandoc.Blocks`. Use `pandoc.RawInline`/`pandoc.RawBlock` for format-specific output.
-Verify the exact handler signature against the shortcodes `.llms.md` page when targeting a specific Quarto version.
+Report failures with `quarto.shortcode.error_output(name, message, context)`, where `context` is `"block"`, `"inline"`, or `"text"`.
 
 ## Writing a Filter
 
@@ -94,7 +112,13 @@ filters:
   - my-filter.lua
 ```
 
-For extension packaging, register in `_extension.yml` instead (see "Quarto Extension Structure" above).
+For extension packaging, list the file under `contributes.filters` in `_extension.yml` (see "Quarto Extension Structure" above).
+Unlike a shortcode extension, a filter extension is not active on its own: the document or project must still name the extension under `filters:`.
+
+```yaml
+filters:
+  - my-extension
+```
 
 Add a file header (see "Lua File Header Convention"), then:
 
@@ -184,10 +208,16 @@ quarto.log.output("my-var:", my_var)
 ### Multi-file Modules
 
 ```lua
-local utils = require("utils")
+local utils = require("./utils")
+local parsing = require("./utils/parsing")
+local shared = require("../shared")
 ```
 
-Quarto resolves `require` paths relative to the calling script's directory.
+Quarto replaces the standard Lua `require()` so that a path starting with `./` or `../` resolves relative to the calling script.
+Always use the relative form.
+A bare `require("utils")` still loads, but the module name is global to the render.
+If two filters each ship a `utils.lua`, the second filter silently receives the module of the first one.
+There is no error, only a wrong result.
 
 ### Testing
 
@@ -195,23 +225,41 @@ Quarto resolves `require` paths relative to the calling script's directory.
 quarto render example.qmd
 ```
 
+## Quarto Lua API Surface
+
+The entries below are names only.
+Read `https://quarto.org/docs/extensions/lua-api.llms.md` for signatures and fields before you use one that this skill does not show in full.
+
+- Version: `quarto.version`.
+- Logging: `quarto.log.output`, `quarto.log.warning`, `quarto.log.debug`.
+- Utilities: `quarto.utils.resolve_path`, `quarto.utils.string_to_inlines`, `quarto.utils.string_to_blocks`.
+- Current render: `quarto.doc.input_file`, `quarto.doc.output_file`.
+- Project: `quarto.project.directory`, `quarto.project.output_directory`, `quarto.project.offset`, `quarto.project.profile`.
+- Format detection: `quarto.doc.is_format`, `quarto.doc.has_bootstrap`, `quarto.doc.cite_method`, `quarto.doc.pdf_engine`.
+- Includes: `quarto.doc.include_text`, `quarto.doc.include_file`.
+- Dependencies: `quarto.doc.add_html_dependency`, `quarto.doc.attach_to_dependency`, `quarto.doc.use_latex_package`, `quarto.doc.add_format_resource`, `quarto.doc.add_resource`, `quarto.doc.add_supporting`.
+- Encoding: `quarto.json.encode`, `quarto.json.decode`, `quarto.base64.encode`, `quarto.base64.decode`.
+- Tool paths: `quarto.paths.rscript`, `quarto.paths.tinytex_bin_dir`, `quarto.paths.typst`.
+- Shortcode helpers: `quarto.shortcode.read_arg`, `quarto.shortcode.error_output`.
+- Metadata and variables: `quarto.metadata.get`, `quarto.variables.get`.
+- Custom node constructors: `quarto.Callout`, `quarto.ConditionalBlock`, `quarto.Tabset`, `quarto.Tab`.
+
+Names that start with `_quarto` are internal to Quarto.
+The one documented exception is `quarto._quarto.ast.add_renderer`, which adds a custom renderer for a custom node type.
+
 ## Custom AST Nodes
 
-Quarto extends Pandoc's AST with custom node types that filters can match by name.
+Quarto extends Pandoc's AST with custom node types that filters match by name, the same way as a Pandoc element.
 
-**Block-level:** Callout, ConditionalBlock, Tabset, PanelLayout, FloatRefTarget, DecoratedCodeBlock, Theorem, Proof.
+Node types: Callout, ConditionalBlock, Tabset, PanelLayout, FloatRefTarget, DecoratedCodeBlock, Theorem, Proof, Shortcode, LatexEnvironment, LatexInlineCommand, HtmlTag.
 
-**Inline-level:** Shortcode.
+Constructors: `quarto.Callout(tbl)`, `quarto.ConditionalBlock(tbl)`, `quarto.Tabset(tbl)`, `quarto.Tab(tbl)`.
 
-**Other:** LatexEnvironment, LatexInlineCommand, HtmlTag.
+Cross-referenceable figures, tables, and listings are all `FloatRefTarget` nodes.
 
-Constructors exist for: `quarto.Callout(tbl)`, `quarto.ConditionalBlock(tbl)`, `quarto.Tabset(tbl)`, `quarto.Tab(tbl)`.
+Filter timing supports eight phases, `pre-ast` through `post-finalize`, set with the `at` property in `_extension.yml` or document YAML.
 
-Cross-referenceable elements (figures, tables, listings) are represented as `FloatRefTarget` nodes.
-
-Filter timing supports eight phases (`pre-ast` through `post-finalize`) via the `at` property in `_extension.yml`.
-
-For full constructor signatures and filter timing details, read `references/custom-ast-nodes.md`.
+For the full node type list, constructor signatures, and timing phases, read `references/custom-ast-nodes.md`.
 
 ## Resources
 

--- a/quarto/quarto-lua/SKILL.md
+++ b/quarto/quarto-lua/SKILL.md
@@ -209,14 +209,19 @@ quarto.log.output("my-var:", my_var)
 
 ```lua
 local utils = require("./utils")
-local parsing = require("./utils/parsing")
-local shared = require("../shared")
+local parsing = require("./sub/parsing")
 ```
 
-Quarto replaces the standard Lua `require()` so that a path starting with `./` or `../` resolves relative to the calling script.
+Quarto replaces the standard Lua `require()` so that a path that starts with `./` or `../` resolves relative to the calling script.
 Always use the relative form.
+
+Inside an extension, keep every module path within the extension directory.
+`quarto add` copies only `_extensions/<name>/`, so a `require("../shared")` that works in the source project stops the render after installation with `cannot open .../_extensions/shared.lua`.
+Put shared code in a subdirectory of the extension instead.
+
 A bare `require("utils")` still loads, but the module name is global to the render.
 If two filters each ship a `utils.lua`, the second filter silently receives the module of the first one.
+This happens across separate installed extensions as well.
 There is no error, only a wrong result.
 
 ### Testing

--- a/quarto/quarto-lua/references/custom-ast-nodes.md
+++ b/quarto/quarto-lua/references/custom-ast-nodes.md
@@ -1,0 +1,84 @@
+# Custom AST Nodes
+
+Quarto extends Pandoc's AST with custom node types.
+Filters match these by name in handler tables (e.g., `{ Callout = handle_callout }`).
+
+## Available Node Types
+
+**Block-level:** Callout, ConditionalBlock, Tabset, PanelLayout, FloatRefTarget, DecoratedCodeBlock, Theorem, Proof.
+
+**Inline-level:** Shortcode.
+
+**Other:** LatexEnvironment, LatexInlineCommand, HtmlTag.
+
+Note: `_quarto.ast.add_handler()` is internal to Quarto.
+Extension authors interact via standard filter handlers.
+
+## Constructor Signatures
+
+### `quarto.Callout(tbl)`
+
+- `type`: `string` - callout type (note, caution, warning, tip, important).
+- `title`: `pandoc.Inlines` or `string` (optional).
+- `icon`: `boolean` or `string` (optional, defaults based on type).
+- `appearance`: `string` - "minimal", "simple", or "default" (optional).
+- `collapse`: collapse state (optional).
+- `content`: `pandoc.Blocks` or list (optional, defaults to empty Blocks).
+- `attr`: `pandoc.Attr` (optional, defaults to empty Attr).
+
+### `quarto.ConditionalBlock(tbl)`
+
+- `node`: `pandoc.Div` - the div holding the content.
+- `behavior`: `string` - "content-visible" or "content-hidden".
+- `condition`: list of 2-element lists (optional, defaults to `{}`).
+  Each sublist: `{"when-format"|"unless-format"|"when-profile"|"unless-profile", value}`.
+
+### `quarto.Tabset(tbl)`
+
+- `tabs`: list of `quarto.Tab` objects (optional, defaults to empty list).
+- `level`: `number` - heading level for tabs (optional, default `2`).
+- `attr`: `pandoc.Attr` (optional, defaults to `pandoc.Attr("", {"panel-tabset"})`).
+
+### `quarto.Tab(tbl)`
+
+- `title`: `pandoc.Inlines` or `string` (required).
+- `content`: `pandoc.Blocks` or `string` (optional, string parsed as markdown).
+- `active`: `boolean` (optional, default `false`).
+
+## Filter Timing
+
+Eight phases available via the `at` property in `_extension.yml` or document YAML:
+
+1. `pre-ast`
+2. `post-ast`
+3. `pre-quarto`
+4. `post-quarto`
+5. `pre-render`
+6. `post-render`
+7. `pre-finalize`
+8. `post-finalize`
+
+Syntax in `_extension.yml` or document YAML:
+
+```yaml
+filters:
+  - path: my-filter.lua
+    at: pre-quarto
+```
+
+Default (no `at`): filters listed before a "quarto" marker get `pre-quarto`, filters listed after get `post-render`.
+
+## FloatRefTarget
+
+Cross-referenceable elements (figures, tables, listings) are represented as `FloatRefTarget` custom AST nodes.
+Filters operating on these should use the `FloatRefTarget` handler:
+
+```lua
+return {
+  { FloatRefTarget = function(el)
+      -- el.caption, el.content, el.identifier, etc.
+      return el
+    end
+  }
+}
+```

--- a/quarto/quarto-lua/references/custom-ast-nodes.md
+++ b/quarto/quarto-lua/references/custom-ast-nodes.md
@@ -47,7 +47,9 @@ Extension authors interact via standard filter handlers.
 
 ## Filter Timing
 
-Eight phases available via the `at` property in `_extension.yml` or document YAML:
+Eight phases available via the `at` property in `_extension.yml` or document YAML.
+This list is the full `filter-entry-point` enum that Quarto validates against.
+The Quarto AST documentation page describes only the first six, so prefer this list.
 
 1. `pre-ast`
 2. `post-ast`

--- a/quarto/quarto-lua/references/custom-ast-nodes.md
+++ b/quarto/quarto-lua/references/custom-ast-nodes.md
@@ -3,13 +3,8 @@
 Quarto extends Pandoc's AST with custom node types.
 Filters match these by name in handler tables (e.g., `{ Callout = handle_callout }`).
 
-## Available Node Types
-
-**Block-level:** Callout, ConditionalBlock, Tabset, PanelLayout, FloatRefTarget, DecoratedCodeBlock, Theorem, Proof.
-
-**Inline-level:** Shortcode.
-
-**Other:** LatexEnvironment, LatexInlineCommand, HtmlTag.
+`SKILL.md` lists the node types.
+Only `Shortcode` is an inline node; the rest are block-level, except `LatexEnvironment`, `LatexInlineCommand`, and `HtmlTag`.
 
 Note: `_quarto.ast.add_handler()` is internal to Quarto.
 Extension authors interact via standard filter handlers.
@@ -68,7 +63,20 @@ filters:
     at: pre-quarto
 ```
 
-Default (no `at`): filters listed before a "quarto" marker get `pre-quarto`, filters listed after get `post-render`.
+Without `at`, the position of the entry decides the phase.
+The literal entry `quarto` in the list is a marker, not a filter.
+Entries before it get `pre-quarto`, entries after it get `post-render`.
+A list with no marker at all is therefore entirely `pre-quarto`.
+
+```yaml
+filters:
+  - runs-at-pre-quarto.lua
+  - quarto
+  - runs-at-post-render.lua
+```
+
+This is the syntax Quarto used before 1.4.
+It still works, and it mixes with `at` entries in the same list.
 
 ## FloatRefTarget
 


### PR DESCRIPTION
Add a new `quarto-lua` skill for writing Lua shortcodes and filters in Quarto.

It covers shortcode handlers, AST filters, Lua conventions, an index of the `quarto.*` API surface, and a decision tree that sends detailed questions to Quarto's `.llms.md` pages.

`references/custom-ast-nodes.md` holds the custom AST node constructors and the eight filter timing phases. It stays in the skill because the `.llms.md` page drops the constructor table (quarto-dev/quarto-cli#14806) and the AST page documents only six of the phases.

### Evaluation

| File | Lines | ~Tokens |
|---|---:|---:|
| SKILL.md | 284 | 2,907 |
| references/custom-ast-nodes.md | 94 | 820 |
| **Total** | **378** | **3,727** |
| Description | - | 84 |
