### PR TITLE
fix(quarto): clean up quarto-authoring skill

### DIFF
--- a/quarto/quarto-authoring/SKILL.md
+++ b/quarto/quarto-authoring/SKILL.md
@@ -9,7 +9,7 @@ description: >
   to Quarto, and creating Quarto websites, books, presentations, and reports.
 metadata:
   author: Mickaël Canouil (@mcanouil)
-  version: "1.1"
+  version: "1.2"
 license: MIT
 ---
 

--- a/quarto/quarto-authoring/SKILL.md
+++ b/quarto/quarto-authoring/SKILL.md
@@ -15,27 +15,12 @@ license: MIT
 
 # Quarto Authoring
 
-> This skill is based on Quarto CLI v1.8.26.
+> This skill is based on Quarto CLI v1.9.30 (2026-03-09).
 
 ## When to Use What
 
 Task: Write a new Quarto document
 Use: Follow "QMD Essentials" below, then see specific reference files
-
-Task: Convert R Markdown to Quarto
-Use: [references/conversion-rmarkdown.md](references/conversion-rmarkdown.md)
-
-Task: Migrate bookdown project
-Use: [references/conversion-bookdown.md](references/conversion-bookdown.md)
-
-Task: Migrate xaringan slides
-Use: [references/conversion-xaringan.md](references/conversion-xaringan.md)
-
-Task: Migrate distill article
-Use: [references/conversion-distill.md](references/conversion-distill.md)
-
-Task: Migrate blogdown site
-Use: [references/conversion-blogdown.md](references/conversion-blogdown.md)
 
 Task: Add cross-references
 Use: [references/cross-references.md](references/cross-references.md)
@@ -78,6 +63,17 @@ Use: [references/extensions.md](references/extensions.md)
 
 Task: Apply markdown linting rules
 Use: [references/markdown-linting.md](references/markdown-linting.md)
+
+### Migration (only when converting an existing project)
+
+Do NOT read these references when writing new Quarto documents.
+Only read the one matching the source format when the user explicitly asks to convert or migrate an existing project.
+
+- R Markdown (.Rmd) to Quarto: [references/conversion-rmarkdown.md](references/conversion-rmarkdown.md)
+- bookdown project: [references/conversion-bookdown.md](references/conversion-bookdown.md)
+- xaringan slides: [references/conversion-xaringan.md](references/conversion-xaringan.md)
+- distill article: [references/conversion-distill.md](references/conversion-distill.md)
+- blogdown site: [references/conversion-blogdown.md](references/conversion-blogdown.md)
 
 ## QMD Essentials
 

--- a/quarto/quarto-authoring/SKILL.md
+++ b/quarto/quarto-authoring/SKILL.md
@@ -15,7 +15,7 @@ license: MIT
 
 # Quarto Authoring
 
-> This skill is based on Quarto CLI v1.9.30 (2026-03-09).
+> This skill is based on Quarto CLI v1.9.36 (2026-03-24).
 
 ## When to Use What
 

--- a/quarto/quarto-authoring/references/callouts.md
+++ b/quarto/quarto-authoring/references/callouts.md
@@ -108,10 +108,10 @@ See @nte-important for details.
 
 ## Nested Callouts
 
-Use more colons for outer divs when nesting:
+Nest callouts inside each other:
 
 ````markdown
-:::: {.callout-note}
+::: {.callout-note}
 
 ## Outer Callout
 
@@ -119,7 +119,7 @@ Use more colons for outer divs when nesting:
 Nested callout.
 :::
 
-::::
+:::
 ````
 
 ## Format-Specific Options

--- a/quarto/quarto-authoring/references/citations.md
+++ b/quarto/quarto-authoring/references/citations.md
@@ -296,5 +296,3 @@ Or use `@Manual` for R packages.
 - [Quarto Citations](https://quarto.org/docs/authoring/citations.html)
 - [Pandoc Citations](https://pandoc.org/MANUAL.html#citations)
 - [CSL Styles](https://citationstyles.org/)
-
-

--- a/quarto/quarto-authoring/references/conditional-content.md
+++ b/quarto/quarto-authoring/references/conditional-content.md
@@ -291,5 +291,3 @@ Basic HTML content.
 
 - [Quarto Conditional Content](https://quarto.org/docs/authoring/conditional.html)
 - [Project Profiles](https://quarto.org/docs/projects/profiles.html)
-
-

--- a/quarto/quarto-authoring/references/conversion-blogdown.md
+++ b/quarto/quarto-authoring/references/conversion-blogdown.md
@@ -235,7 +235,7 @@ Install extension: `quarto add sellorm/quarto-social-embeds`
 
 ````markdown
 {{</* youtube VIDEO_ID */>}}
-```
+````
 
 #### Quarto
 
@@ -259,7 +259,7 @@ Install extension: `quarto add sellorm/quarto-social-embeds`
 {{</* highlight r */>}}
 code here
 {{</* /highlight */>}}
-```
+````
 
 #### Quarto
 
@@ -528,4 +528,3 @@ Check for Hugo-specific template syntax in content files.
 - [Quarto Websites](https://quarto.org/docs/websites/)
 - [Quarto Blogs](https://quarto.org/docs/websites/website-blog.html)
 - [Quarto Themes](https://quarto.org/docs/output-formats/html-themes.html)
-

--- a/quarto/quarto-authoring/references/conversion-xaringan.md
+++ b/quarto/quarto-authoring/references/conversion-xaringan.md
@@ -374,7 +374,7 @@ Content fades in
 ::: {.fragment .fade-in}
 Content fades in
 :::
-```
+````
 
 Fragment types:
 
@@ -463,4 +463,3 @@ format:
 - [Quarto RevealJS](https://quarto.org/docs/presentations/revealjs/)
 - [RevealJS Options](https://quarto.org/docs/reference/formats/presentations/revealjs.html)
 - [Presentation Features](https://quarto.org/docs/presentations/)
-

--- a/quarto/quarto-authoring/references/divs-and-spans.md
+++ b/quarto/quarto-authoring/references/divs-and-spans.md
@@ -180,7 +180,7 @@ Raw LaTeX content.
 
 ### Inline Raw Content
 
-`arkdown
+````markdown
 Text with `<br>`{=html} line break.
 ````
 
@@ -341,5 +341,3 @@ Special classes:
 
 - [Pandoc Divs and Spans](https://pandoc.org/MANUAL.html#divs-and-spans)
 - [Quarto Markdown Basics](https://quarto.org/docs/authoring/markdown-basics.html)
-
-

--- a/quarto/quarto-authoring/references/divs-and-spans.md
+++ b/quarto/quarto-authoring/references/divs-and-spans.md
@@ -40,7 +40,7 @@ Content with attributes.
 
 ## Nested Divs
 
-Use more colons for outer div:
+Nest divs inside each other:
 
 ````markdown
 ::: {.outer}

--- a/quarto/quarto-authoring/references/layout.md
+++ b/quarto/quarto-authoring/references/layout.md
@@ -425,5 +425,3 @@ KOMA classes support margin content automatically.
 - [Quarto Article Layout](https://quarto.org/docs/authoring/article-layout.html)
 - [Page Layout](https://quarto.org/docs/output-formats/page-layout.html)
 - [Figures Layout](https://quarto.org/docs/authoring/figures.html#figure-panels)
-
-

--- a/quarto/quarto-authoring/references/markdown-linting.md
+++ b/quarto/quarto-authoring/references/markdown-linting.md
@@ -79,7 +79,7 @@ Key points:
 
 - Blank line before opening `:::`.
 - Blank line after closing `:::`.
-- Use `::::` (four+ colons) for nesting outer divs.
+- Use `:::` (three colons) for both opening and closing divs, including when nesting.
 
 ## Resources
 


### PR DESCRIPTION
Update the quarto-authoring skill to Quarto CLI v1.9.30 and fix several issues found.

- Update pinned Quarto CLI version from v1.8.26 to v1.9.30.
- Fix broken code fences in `divs-and-spans.md`, `conversion-blogdown.md`, and `conversion-xaringan.md`.
- Use three colons consistently for div syntax in `callouts.md` nested example and `markdown-linting.md` guidance.
- Move migration references into a gated subsection with an explicit instruction not to read them during normal authoring tasks, saving ~8,600 tokens of unnecessary context.

### Evaluation

| File | Lines | ~Tokens |
|---|---:|---:|
| SKILL.md | 319 | 1,909 |
| references/callouts.md | 178 | 884 |
| references/citations.md | 298 | 1,436 |
| references/code-cells.md | 282 | 1,816 |
| references/conditional-content.md | 293 | 1,196 |
| references/conversion-blogdown.md | 530 | 1,978 |
| references/conversion-bookdown.md | 417 | 1,662 |
| references/conversion-distill.md | 436 | 1,704 |
| references/conversion-rmarkdown.md | 337 | 1,676 |
| references/conversion-xaringan.md | 465 | 1,588 |
| references/cross-references.md | 315 | 1,774 |
| references/diagrams.md | 287 | 1,361 |
| references/divs-and-spans.md | 343 | 1,235 |
| references/extensions.md | 319 | 1,353 |
| references/figures.md | 288 | 1,480 |
| references/layout.md | 427 | 1,670 |
| references/markdown-linting.md | 88 | 498 |
| references/shortcodes.md | 374 | 1,462 |
| references/tables.md | 375 | 1,829 |
| references/yaml-front-matter.md | 419 | 1,863 |
| **Total** | **6,790** | **30,374** |
| Description | - | 99 |