### PR TITLE
refactor(quarto-authoring): make skill language-agnostic, add engines and jupyter refs

### DIFF
--- a/quarto/quarto-authoring/SKILL.md
+++ b/quarto/quarto-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quarto-authoring
-description: Writing and authoring Quarto documents (.qmd) with the knitr, jupyter, and julia engines (and any Quarto 1.9+ engine extensions). Covers code cell options, figure and table captions, cross-references, callout blocks (notes, warnings, tips), citations and bibliography, page layout and columns, Mermaid diagrams, YAML metadata configuration, and Quarto extensions. Also covers converting and migrating R Markdown (.Rmd), bookdown, blogdown, xaringan, distill projects, and Jupyter notebooks (.ipynb) to Quarto, and creating Quarto websites, books, presentations, and reports.
+description: Use when working with Quarto (.qmd) documents, code cells, cross-references, callouts, citations, YAML frontmatter, Mermaid diagrams, or Quarto extensions. Also use when migrating R Markdown (.Rmd), bookdown, blogdown, xaringan, distill, or Jupyter notebooks (.ipynb) to Quarto, or creating Quarto websites, books, presentations, or reports.
 metadata:
   author: Mickaël Canouil (@mcanouil)
   version: "1.4"

--- a/quarto/quarto-authoring/SKILL.md
+++ b/quarto/quarto-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quarto-authoring
-description: Use when working with Quarto (.qmd) documents, code cells, cross-references, callouts, citations, YAML frontmatter, Mermaid diagrams, or Quarto extensions. Also use when migrating R Markdown (.Rmd), bookdown, blogdown, xaringan, distill, or Jupyter notebooks (.ipynb) to Quarto, or creating Quarto websites, books, presentations, or reports.
+description: Use when the user is explicitly working with Quarto, .qmd files, _quarto.yml, Quarto projects, or Quarto features such as callouts, cross-references, citations, Mermaid diagrams, extensions, websites, books, presentations, and reports. Also use for explicit migration from or comparison with R Markdown, bookdown, blogdown, xaringan, distill, or Jupyter notebooks to Quarto. Do not use for general R Markdown or related-format questions unless Quarto or migration to Quarto is explicitly mentioned.
 metadata:
   author: Mickaël Canouil (@mcanouil)
   version: "1.4"

--- a/quarto/quarto-authoring/SKILL.md
+++ b/quarto/quarto-authoring/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: quarto-authoring
 description: >
-  Writing and authoring Quarto documents (.qmd), including code cell options,
-  figure and table captions, cross-references, callout blocks (notes, warnings,
-  tips), citations and bibliography, page layout and columns, Mermaid diagrams,
-  YAML metadata configuration, and Quarto extensions. Also covers converting and
-  migrating R Markdown (.Rmd), bookdown, blogdown, xaringan, and distill projects
-  to Quarto, and creating Quarto websites, books, presentations, and reports.
+  Writing and authoring Quarto documents (.qmd) with any compute engine (knitr,
+  jupyter, julia). Covers code cell options, figure and table captions,
+  cross-references, callout blocks, citations, page layout, Mermaid diagrams,
+  YAML metadata, and extensions. Also covers converting R Markdown, bookdown,
+  blogdown, xaringan, distill, and Jupyter notebooks to Quarto, and creating
+  websites, books, presentations, and reports.
 metadata:
   author: Mickaël Canouil (@mcanouil)
-  version: "1.1"
+  version: "1.2"
 license: MIT
 ---
 
 # Quarto Authoring
 
-> This skill is based on Quarto CLI v1.8.26.
+> This skill is based on Quarto CLI v1.9.36.
 
 ## When to Use What
 
@@ -36,6 +36,9 @@ Use: [references/conversion-distill.md](references/conversion-distill.md)
 
 Task: Migrate blogdown site
 Use: [references/conversion-blogdown.md](references/conversion-blogdown.md)
+
+Task: Convert Jupyter notebook (.ipynb) to Quarto (.qmd), or Quarto to .ipynb
+Use: [references/conversion-jupyter.md](references/conversion-jupyter.md)
 
 Task: Add cross-references
 Use: [references/cross-references.md](references/cross-references.md)
@@ -78,6 +81,9 @@ Use: [references/extensions.md](references/extensions.md)
 
 Task: Apply markdown linting rules
 Use: [references/markdown-linting.md](references/markdown-linting.md)
+
+Task: Choose or configure a compute engine (knitr, jupyter, julia)
+Use: [references/engines.md](references/engines.md)
 
 ## QMD Essentials
 
@@ -124,30 +130,19 @@ Code cells are code blocks that can be executed to produce output.
 
 Quarto uses the language's comment symbol + `|` for cell options. Options use **dashes, not dots** (e.g., `fig-cap` not `fig.cap`).
 
-- R, Python: `#|`
+- R, Python, Julia: `#|`
 - Mermaid: `%%|`
 - Graphviz/DOT: `//|`
 
 ````markdown
-```{r}
+```{language}
 #| label: fig-example
 #| echo: false
 #| fig-cap: "A scatter plot example."
 
-plot(x, y)
+# code that produces a figure
 ```
 ````
-
-Common execution options:
-
-| Option    | Description       | Values                    |
-| --------- | ----------------- | ------------------------- |
-| `eval`    | Evaluate code     | `true`, `false`           |
-| `echo`    | Show code         | `true`, `false`, `fenced` |
-| `output`  | Include output    | `true`, `false`, `asis`   |
-| `warning` | Show warnings     | `true`, `false`           |
-| `error`   | Show errors       | `true`, `false`           |
-| `include` | Include in output | `true`, `false`           |
 
 Set document-level defaults in YAML front matter:
 
@@ -169,10 +164,11 @@ Labels must start with a type prefix. Reference with `@`:
 - Equation: `eq-` prefix, e.g., `{#eq-model}` → `@eq-model`
 
 ````markdown
-```{r}
+```{language}
 #| label: fig-plot
 #| fig-cap: "A caption for the plot."
-plot(1)
+
+# code that produces a figure
 ```
 
 See @fig-plot for the results.

--- a/quarto/quarto-authoring/SKILL.md
+++ b/quarto/quarto-authoring/SKILL.md
@@ -149,6 +149,16 @@ execute:
   warning: false
 ```
 
+**Caching — critical engine difference:** Only suggest `#| cache: true` for R code cells (knitr engine).
+Never suggest it for other language cells — it does not work and will be silently ignored.
+The only correct approach is `execute: cache: true` in the top-level YAML front matter when using engines other than `knitr`.
+Python/Jupyter requires `jupyter-cache` (`pip install jupyter-cache`):
+
+```yaml
+execute:
+  cache: true
+```
+
 Details: [references/code-cells.md](references/code-cells.md)
 
 ### Cross-References

--- a/quarto/quarto-authoring/SKILL.md
+++ b/quarto/quarto-authoring/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: quarto-authoring
 description: >
-  Writing and authoring Quarto documents (.qmd) with any compute engine (knitr,
-  jupyter, julia). Covers code cell options, figure and table captions,
-  cross-references, callout blocks, citations, page layout, Mermaid diagrams,
-  YAML metadata, and extensions. Also covers converting R Markdown, bookdown,
-  blogdown, xaringan, distill, and Jupyter notebooks to Quarto, and creating
-  websites, books, presentations, and reports.
+  Writing and authoring Quarto documents (.qmd) with the knitr, jupyter, and
+  julia engines (and any Quarto 1.9+ engine extensions). Covers code cell
+  options, figure and table captions, cross-references, callout blocks
+  (notes, warnings, tips), citations and bibliography, page layout and
+  columns, Mermaid diagrams, YAML metadata configuration, and Quarto
+  extensions. Also covers converting and migrating R Markdown (.Rmd),
+  bookdown, blogdown, xaringan, distill projects, and Jupyter notebooks
+  (.ipynb) to Quarto, and creating Quarto websites, books, presentations,
+  and reports.
 metadata:
   author: Mickaël Canouil (@mcanouil)
   version: "1.4"

--- a/quarto/quarto-authoring/SKILL.md
+++ b/quarto/quarto-authoring/SKILL.md
@@ -1,15 +1,6 @@
 ---
 name: quarto-authoring
-description: >
-  Writing and authoring Quarto documents (.qmd) with the knitr, jupyter, and
-  julia engines (and any Quarto 1.9+ engine extensions). Covers code cell
-  options, figure and table captions, cross-references, callout blocks
-  (notes, warnings, tips), citations and bibliography, page layout and
-  columns, Mermaid diagrams, YAML metadata configuration, and Quarto
-  extensions. Also covers converting and migrating R Markdown (.Rmd),
-  bookdown, blogdown, xaringan, distill projects, and Jupyter notebooks
-  (.ipynb) to Quarto, and creating Quarto websites, books, presentations,
-  and reports.
+description: Writing and authoring Quarto documents (.qmd) with the knitr, jupyter, and julia engines (and any Quarto 1.9+ engine extensions). Covers code cell options, figure and table captions, cross-references, callout blocks (notes, warnings, tips), citations and bibliography, page layout and columns, Mermaid diagrams, YAML metadata configuration, and Quarto extensions. Also covers converting and migrating R Markdown (.Rmd), bookdown, blogdown, xaringan, distill projects, and Jupyter notebooks (.ipynb) to Quarto, and creating Quarto websites, books, presentations, and reports.
 metadata:
   author: Mickaël Canouil (@mcanouil)
   version: "1.4"

--- a/quarto/quarto-authoring/references/callouts.md
+++ b/quarto/quarto-authoring/references/callouts.md
@@ -6,11 +6,11 @@ Callouts are specially formatted blocks for notes, warnings, tips, and other hig
 
 Five built-in types: `note`, `warning`, `important`, `tip`, `caution`.
 
-````markdown
+```markdown
 ::: {.callout-note}
 This is a note callout.
 :::
-````
+```
 
 Replace `note` with any other type (`warning`, `important`, `tip`, `caution`) for the corresponding style.
 
@@ -18,7 +18,7 @@ Replace `note` with any other type (`warning`, `important`, `tip`, `caution`) fo
 
 Use a heading for custom title:
 
-````markdown
+```markdown
 ::: {.callout-note}
 
 ## Custom Title Here
@@ -26,25 +26,25 @@ Use a heading for custom title:
 Content of the callout.
 
 :::
-````
+```
 
 Or use `title` attribute:
 
-````markdown
+```markdown
 ::: {.callout-note title="My Custom Title"}
 Content of the callout.
 :::
-````
+```
 
 ## Appearance Options
 
 Three styles: `default` (colored header with icon), `simple` (lighter, no colored header), `minimal` (borders only).
 
-````markdown
+```markdown
 ::: {.callout-note appearance="simple"}
 Simple appearance.
 :::
-````
+```
 
 Set document default in YAML:
 
@@ -54,7 +54,7 @@ callout-appearance: simple
 
 ## Collapsible Callouts
 
-````markdown
+```markdown
 ::: {.callout-tip collapse="true"}
 
 ## Expand for Details
@@ -62,7 +62,7 @@ callout-appearance: simple
 Hidden content revealed on click.
 
 :::
-````
+```
 
 `collapse="true"` starts collapsed. `collapse="false"` starts expanded but is collapsible. Without `collapse`, the callout is not collapsible.
 
@@ -70,11 +70,11 @@ Hidden content revealed on click.
 
 Disable per-callout or document-wide:
 
-````markdown
+```markdown
 ::: {.callout-note icon="false"}
 No icon on this callout.
 :::
-````
+```
 
 ```yaml
 callout-icon: false
@@ -84,7 +84,7 @@ callout-icon: false
 
 Add an ID with the appropriate prefix to reference callouts:
 
-````markdown
+```markdown
 ::: {#nte-important .callout-note}
 
 ## Important Information
@@ -94,7 +94,7 @@ This callout can be referenced.
 :::
 
 See @nte-important for details.
-````
+```
 
 ### Callout Prefixes
 
@@ -110,8 +110,8 @@ See @nte-important for details.
 
 Use more colons for outer divs when nesting:
 
-````markdown
-:::: {.callout-note}
+```markdown
+::: {.callout-note}
 
 ## Outer Callout
 
@@ -119,8 +119,8 @@ Use more colons for outer divs when nesting:
 Nested callout.
 :::
 
-::::
-````
+:::
+```
 
 ## Format-Specific Options
 

--- a/quarto/quarto-authoring/references/code-cells.md
+++ b/quarto/quarto-authoring/references/code-cells.md
@@ -158,13 +158,11 @@ For markdown table output from code, use `output: asis` (see the [output: asis](
 
 ## Caching and Freeze
 
-> **`#| cache: true` is only supported by the knitr engine at cell level.
-> Do NOT use it on individual cells with the jupyter or julia engines — it has no effect.**
+Only suggest `#| cache: true` for R code cells (knitr engine).
+It is not valid for Python or Julia cells — the jupyter engine silently ignores it.
 
-**knitr engine**: use `#| cache: true` per cell to store results independently.
-
-**jupyter and other non-knitr engines**: caching is document-level only, managed by `jupyter-cache`.
-Enable it in YAML front matter; individual cells cannot opt in — they can only opt out with `#| cache: false`.
+For Python and Julia, caching is document-level only.
+Install `jupyter-cache` (`pip install jupyter-cache`) and set in YAML front matter:
 
 ```yaml
 execute:

--- a/quarto/quarto-authoring/references/code-cells.md
+++ b/quarto/quarto-authoring/references/code-cells.md
@@ -7,29 +7,20 @@ Quarto uses a hashpipe (`#|`) syntax for code cell options, providing a clean, Y
 Code cell options are specified with `#|` at the start of lines within the code block:
 
 ````markdown
-```{r}
+```{language}
 #| label: fig-scatter
 #| echo: false
 #| fig-cap: "A scatter plot of x versus y."
 #| fig-width: 8
 #| fig-height: 6
 
-plot(x, y)
-```
-````
-
-````markdown
-```{python}
-#| label: fig-histogram
-#| fig-cap: "Distribution of values."
-
-import matplotlib.pyplot as plt
-plt.hist(data)
-plt.show()
+# code that produces a scatter plot
 ```
 ````
 
 **Important:** Options use **dashes, not dots**. Use `fig-cap` not `fig.cap`, `fig-width` not `fig.width`.
+
+The hashpipe prefix is `#|` for R, Python, and Julia; diagram cells use a different prefix. See [engines.md](engines.md) for the full table.
 
 ## Execution Options
 
@@ -49,32 +40,30 @@ Control whether and how code is executed:
 Show code but don't run it:
 
 ````markdown
-```{r}
+```{language}
 #| eval: false
 
 # This code is displayed but not executed
-x <- 1 + 1
 ```
 ````
 
 Run code but hide it:
 
 ````markdown
-```{r}
+```{language}
 #| echo: false
 
 # This code runs but is not shown
-library(ggplot2)
 ```
 ````
 
 Show fenced code block with attributes:
 
 ````markdown
-```{r}
+```{language}
 #| echo: fenced
 
-plot(1:10)
+# code here
 ```
 ````
 
@@ -97,7 +86,7 @@ Options for controlling figure output:
 ### Figure Example
 
 ````markdown
-```{r}
+```{language}
 #| label: fig-analysis
 #| fig-cap: "Analysis results showing the relationship between variables."
 #| fig-alt: "Scatter plot with trend line showing positive correlation."
@@ -105,16 +94,14 @@ Options for controlling figure output:
 #| fig-height: 6
 #| fig-align: center
 
-ggplot(data, aes(x, y)) +
-  geom_point() +
-  geom_smooth()
+# code that produces a scatter plot with trend line
 ```
 ````
 
 ### Multiple Figures
 
 ````markdown
-```{r}
+```{language}
 #| label: fig-panels
 #| fig-cap: "Multiple panel figure."
 #| fig-subcap:
@@ -122,8 +109,7 @@ ggplot(data, aes(x, y)) +
 #|   - "Distribution of Y"
 #| layout-ncol: 2
 
-hist(x)
-hist(y)
+# code that produces two figures (one per panel)
 ```
 ````
 
@@ -141,11 +127,24 @@ Options for controlling table output:
 ### Table Example
 
 ````markdown
-```{r}
+```{language}
 #| label: tbl-summary
 #| tbl-cap: "Summary statistics by group."
 
-knitr::kable(summary_data)
+# code that produces a table
+```
+````
+
+Table rendering behaviour differs between the knitr and jupyter engines; see [tables.md](tables.md) for details.
+Use `output: asis` to emit a pre-formatted markdown or HTML string:
+
+````markdown
+```{language}
+#| label: tbl-summary
+#| tbl-cap: "Summary statistics by group."
+#| output: asis
+
+# print a markdown table string to stdout
 ```
 ````
 
@@ -162,12 +161,11 @@ Control caching of code cell results:
 ### Caching Example
 
 ````markdown
-```{r}
+```{language}
 #| label: slow-computation
 #| cache: true
 
 # This expensive computation is cached
-result <- slow_function(data)
 ```
 ````
 
@@ -228,11 +226,10 @@ format:
 Per cell override:
 
 ````markdown
-```{r}
+```{language}
 #| code-fold: show
 
 # This code is visible by default
-plot(1:10)
 ```
 ````
 
@@ -241,19 +238,18 @@ plot(1:10)
 Add annotations to explain code:
 
 ````markdown
-```{r}
+```{language}
 #| code-annotations: hover
 
-library(tidyverse)
-mtcars |>                 # <1>
-  filter(mpg > 20) |>     # <2>
-  select(mpg, cyl, hp)    # <3>
+step_one()   # <1>
+step_two()   # <2>
+step_three() # <3>
 ```
 ````
 
-1. Start with the mtcars dataset
-2. Filter to cars with MPG over 20
-3. Select only the columns we need
+1. First step description.
+2. Second step description.
+3. Third step description.
 
 Annotation styles: `hover`, `select`, `below`, `beside`.
 
@@ -262,11 +258,10 @@ Annotation styles: `hover`, `select`, `below`, `beside`.
 Show a filename above the code block:
 
 ````markdown
-```{python}
-#| filename: "analysis.py"
+```{language}
+#| filename: "analysis.ext"
 
-import pandas as pd
-df = pd.read_csv("data.csv")
+# code here
 ```
 ````
 
@@ -276,7 +271,7 @@ R Markdown uses dots (`.`), Quarto uses dashes (`-`): `fig.cap` → `fig-cap`, `
 
 ## Resources
 
-- [Quarto Code Cells](https://quarto.org/docs/computations/execution-options.html)
-- [Quarto Figures](https://quarto.org/docs/authoring/figures.html)
+- [Quarto Execution Options](https://quarto.org/docs/computations/execution-options.html)
 - [Code Annotation](https://quarto.org/docs/authoring/code-annotation.html)
-
+- [Code Cells: Knitr](https://quarto.org/docs/reference/cells/cells-knitr.html)
+- [Code Cells: Jupyter](https://quarto.org/docs/reference/cells/cells-jupyter.html)

--- a/quarto/quarto-authoring/references/code-cells.md
+++ b/quarto/quarto-authoring/references/code-cells.md
@@ -158,10 +158,13 @@ For markdown table output from code, use `output: asis` (see the [output: asis](
 
 ## Caching and Freeze
 
-**knitr engine**: cell-level caching with `#| cache: true` stores results per cell.
+> **`#| cache: true` is only supported by the knitr engine at cell level.
+> Do NOT use it on individual cells with the jupyter or julia engines — it has no effect.**
 
-**jupyter engine**: caching is managed by `jupyter-cache` at document level via `execute: cache: true` in YAML front matter.
-Individual cells can opt out with `#| cache: false` but cannot opt in with `#| cache: true`.
+**knitr engine**: use `#| cache: true` per cell to store results independently.
+
+**jupyter and other non-knitr engines**: caching is document-level only, managed by `jupyter-cache`.
+Enable it in YAML front matter; individual cells cannot opt in — they can only opt out with `#| cache: false`.
 
 ```yaml
 execute:

--- a/quarto/quarto-authoring/references/code-cells.md
+++ b/quarto/quarto-authoring/references/code-cells.md
@@ -67,6 +67,24 @@ Show fenced code block with attributes:
 ```
 ````
 
+### output: asis
+
+`output: asis` passes the cell output through as raw content without further Quarto processing.
+Use it when your code prints a pre-formatted markdown or raw string that Quarto should treat as document content.
+
+Requirements:
+
+- The output must already be valid markdown (pipe table, headings, prose) or a raw block (` ```{=html} `, ` ```{=latex} `).
+- `tbl-cap` on an `output: asis` cell does not behave identically to the knitr table-rendering path; prefer a div-wrapped caption for reliability.
+
+````markdown
+```{language}
+#| output: asis
+
+# print("| Col A | Col B |\n| ----- | ----- |\n| 1     | 2     |")
+```
+````
+
 ## Figure Options
 
 Options for controlling figure output:
@@ -136,38 +154,21 @@ Options for controlling table output:
 ````
 
 Table rendering behaviour differs between the knitr and jupyter engines; see [tables.md](tables.md) for details.
-Use `output: asis` to emit a pre-formatted markdown or HTML string:
-
-````markdown
-```{language}
-#| label: tbl-summary
-#| tbl-cap: "Summary statistics by group."
-#| output: asis
-
-# print a markdown table string to stdout
-```
-````
+For markdown table output from code, use `output: asis` (see the [output: asis](#output-asis) section above).
 
 ## Caching and Freeze
 
-Control caching of code cell results:
+**knitr engine**: cell-level caching with `#| cache: true` stores results per cell.
 
-| Option       | Description                         | Values                    |
-| ------------ | ----------------------------------- | ------------------------- |
-| `cache`      | Cache results                       | `true`, `false`           |
-| `cache-lazy` | Use lazy loading for cached objects | `true`, `false`           |
-| `freeze`     | Never re-render (project option)    | `true`, `false`, `"auto"` |
+**jupyter engine**: caching is managed by `jupyter-cache` at document level via `execute: cache: true` in YAML front matter.
+Individual cells can opt out with `#| cache: false` but cannot opt in with `#| cache: true`.
 
-### Caching Example
-
-````markdown
-```{language}
-#| label: slow-computation
-#| cache: true
-
-# This expensive computation is cached
+```yaml
+execute:
+  cache: true
 ```
-````
+
+For details see <https://quarto.org/docs/projects/code-execution.html#cache>.
 
 ### Project-Level Freeze
 

--- a/quarto/quarto-authoring/references/conditional-content.md
+++ b/quarto/quarto-authoring/references/conditional-content.md
@@ -8,31 +8,31 @@ Quarto allows content to be shown or hidden based on output format, metadata, or
 
 Show content only for specific formats:
 
-````markdown
+```markdown
 ::: {.content-visible when-format="html"}
 This only appears in HTML output.
 :::
-````
+```
 
 ### Content Hidden
 
 Hide content for specific formats:
 
-````markdown
+```markdown
 ::: {.content-hidden when-format="pdf"}
 This appears everywhere except PDF.
 :::
-````
+```
 
 ### Unless Format
 
 Show unless a specific format:
 
-````markdown
+```markdown
 ::: {.content-visible unless-format="html"}
 This appears in PDF, DOCX, etc., but not HTML.
 :::
-````
+```
 
 ## Format Values
 
@@ -61,40 +61,40 @@ Quarto groups related formats:
 
 ### Example with Aliases
 
-````markdown
+```markdown
 ::: {.content-visible when-format="pdf"}
 This appears in PDF, LaTeX, and Beamer.
 :::
-````
+```
 
 ## Multiple Formats
 
 ### Either Format
 
-````markdown
+```markdown
 ::: {.content-visible when-format="html"}
 ::: {.content-visible when-format="revealjs"}
 This appears in HTML or RevealJS.
 :::
 :::
-````
+```
 
 Or use aliases:
 
-````markdown
+```markdown
 ::: {.content-visible when-format="html"}
 Appears in all HTML-based formats.
 :::
-````
+```
 
 ## Inline Conditions
 
 For inline content, use spans:
 
-````markdown
+```markdown
 View the [interactive version]{.content-visible when-format="html"}
 [figure]{.content-visible when-format="pdf"}.
-````
+```
 
 ## Metadata-Based Conditions
 
@@ -102,11 +102,11 @@ View the [interactive version]{.content-visible when-format="html"}
 
 Show based on metadata values:
 
-````markdown
+```markdown
 ::: {.content-visible when-meta="draft"}
 DRAFT - Not for distribution.
 :::
-````
+```
 
 With YAML:
 
@@ -116,19 +116,19 @@ draft: true
 
 ### Unless Meta
 
-````markdown
+```markdown
 ::: {.content-visible unless-meta="draft"}
 Final version content.
 :::
-````
+```
 
 ### Nested Metadata
 
-````markdown
+```markdown
 ::: {.content-visible when-meta="params.show-advanced"}
 Advanced content here.
 :::
-````
+```
 
 YAML:
 
@@ -153,7 +153,7 @@ profile:
 
 ### Profile-Specific Content
 
-````markdown
+```markdown
 ::: {.content-visible when-profile="development"}
 Debug information here.
 :::
@@ -161,7 +161,7 @@ Debug information here.
 ::: {.content-visible when-profile="production"}
 Production content only.
 :::
-````
+```
 
 ### Using Profiles
 
@@ -176,18 +176,16 @@ quarto render --profile development
 ````markdown
 ::: {.content-visible when-format="html"}
 
-```{r}
-# Interactive plot for HTML
-plotly::plot_ly(data)
+```{language}
+# interactive output for HTML
 ```
 
 :::
 
 ::: {.content-visible when-format="pdf"}
 
-```{r}
-# Static plot for PDF
-plot(data)
+```{language}
+# static output for PDF
 ```
 
 :::
@@ -231,7 +229,7 @@ See [QUARTO_EXECUTE_INFO](https://quarto.org/docs/advanced/quarto-execute-info.h
 
 Include different files based on format:
 
-````markdown
+```markdown
 ::: {.content-visible when-format="html"}
 
 {{< include _interactive-content.qmd >}}
@@ -243,7 +241,7 @@ Include different files based on format:
 {{< include _static-content.qmd >}}
 
 :::
-````
+```
 
 ## Conditional YAML
 
@@ -265,17 +263,17 @@ format:
 
 ### Combining Conditions
 
-````markdown
+```markdown
 ::: {.content-visible when-format="html" when-meta="interactive"}
 Interactive HTML content.
 :::
-````
+```
 
 Both conditions must be true.
 
 ### Nested Conditions
 
-````markdown
+```markdown
 ::: {.content-visible when-format="html"}
 
 ::: {.content-visible when-meta="advanced"}
@@ -285,11 +283,9 @@ Advanced HTML content.
 Basic HTML content.
 
 :::
-````
+```
 
 ## Resources
 
 - [Quarto Conditional Content](https://quarto.org/docs/authoring/conditional.html)
 - [Project Profiles](https://quarto.org/docs/projects/profiles.html)
-
-

--- a/quarto/quarto-authoring/references/conversion-jupyter.md
+++ b/quarto/quarto-authoring/references/conversion-jupyter.md
@@ -1,17 +1,16 @@
 # Jupyter Notebook (.ipynb) and Quarto (.qmd) Interoperability
 
-Quarto can render `.ipynb` files directly and convert between `.ipynb` and `.qmd` in both directions.
+## Direct Rendering
 
-## Direct Rendering (No Conversion Required)
-
-Quarto renders `.ipynb` files as-is:
+Quarto renders `.ipynb` files without conversion:
 
 ```bash
 quarto render notebook.ipynb
 quarto render notebook.ipynb --to pdf
 ```
 
-Cell outputs stored in the notebook are used by default; set `execute: enabled: true` to force re-execution.
+Cell outputs stored in the notebook are used by default.
+Set `execute: enabled: true` in YAML front matter to force re-execution.
 
 ## Converting Between Formats
 
@@ -22,104 +21,17 @@ quarto convert notebook.ipynb   # → notebook.qmd
 quarto convert notebook.qmd     # → notebook.ipynb
 ```
 
-Converting `.ipynb` → `.qmd`: extracts cell source into code blocks, converts markdown cells to prose, and discards stored outputs (Quarto re-executes on next render).
+Converting `.ipynb` → `.qmd` extracts cell source into code blocks, converts markdown cells to prose, and discards stored outputs (Quarto re-executes on next render).
 
-Converting `.qmd` → `.ipynb`: produces a notebook with cells matching the `.qmd` structure, without executing them.
-
-## Key Differences: .ipynb vs .qmd
-
-| Feature         | .ipynb                 | .qmd                      |
-| --------------- | ---------------------- | ------------------------- |
-| Cell options    | Cell metadata JSON     | Hashpipe comments (`#\|`) |
-| Version control | JSON (noisy diffs)     | Plain text (clean diffs)  |
-| Edit experience | Jupyter UI             | Any text editor           |
-| Inline outputs  | Stored in file         | Re-computed on render     |
-
-## Cell Option Migration
-
-Jupyter cell metadata becomes hashpipe options in `.qmd`.
-
-**Before (.ipynb cell metadata):**
-
-```json
-{
-  "tags": ["remove-input"]
-}
-```
-
-**After (.qmd):**
-
-```
-#| echo: false
-```
-
-### Common Metadata Mappings
-
-Quarto options use the `#|` prefix in code cells.
-
-| Jupyter / nbconvert tag         | Quarto option      |
-| ------------------------------- | ------------------ |
-| `remove-input` / `hide-input`   | `echo: false`      |
-| `remove-output` / `hide-output` | `output: false`    |
-| `remove-cell`                   | `include: false`   |
-| `raises-exception`              | `error: true`      |
-
-## YAML Front Matter
-
-`.qmd` files use YAML front matter; `.ipynb` files use notebook-level metadata JSON.
-After converting `.ipynb` → `.qmd`, add YAML at the top:
-
-```yaml
----
-title: "My Analysis"
-author: "Jane Doe"
-date: today
-format: html
-execute:
-  echo: true
-  warning: false
-jupyter: python3
----
-```
-
-For engine and kernel selection, see [engines.md](engines.md).
-
-## Controlling Re-Execution
-
-For `.ipynb` files, Quarto uses stored cell outputs by default.
-For `.qmd` files, Quarto re-executes all cells on every render.
-
-To use stored outputs when rendering a `.qmd` (e.g. after `quarto convert`):
-
-```yaml
-execute:
-  enabled: false
-```
-
-To force re-execution of a `.ipynb`:
-
-```yaml
-execute:
-  enabled: true
-```
-
-For project-level caching and freeze, see [engines.md](engines.md).
+Converting `.qmd` → `.ipynb` produces a notebook matching the `.qmd` structure, without executing cells.
 
 ## When to Use Each Format
 
-Prefer `.qmd` when:
+Prefer `.qmd` for version-controlled documents: plain text produces clean diffs, cell options use hashpipe syntax (`#|`) instead of JSON metadata, and any text editor can be used.
 
-- The document is under version control (clean diffs, no output blobs).
-- You want hashpipe options instead of JSON cell metadata.
-- You are working in any editor, not just Jupyter UI.
-
-Prefer `.ipynb` when:
-
-- The notebook is primarily interactive exploration.
-- It is shared with users who do not use Quarto.
-- It relies heavily on Jupyter widgets.
+Prefer `.ipynb` for interactive exploration, sharing with users who do not use Quarto, or workflows that rely heavily on Jupyter widgets.
 
 ## Resources
 
-- [Jupyter Kernel Execution](https://quarto.org/docs/advanced/jupyter/kernel-execution.html)
-- [Quarto convert CLI](https://quarto.org/docs/cli/convert.html)
+- [Quarto convert CLI](https://quarto.org/docs/tools/jupyter-lab.html)
+- [Jupyter Kernel Execution](https://quarto.org/docs/computations/jupyter.html)

--- a/quarto/quarto-authoring/references/conversion-jupyter.md
+++ b/quarto/quarto-authoring/references/conversion-jupyter.md
@@ -1,0 +1,125 @@
+# Jupyter Notebook (.ipynb) and Quarto (.qmd) Interoperability
+
+Quarto can render `.ipynb` files directly and convert between `.ipynb` and `.qmd` in both directions.
+
+## Direct Rendering (No Conversion Required)
+
+Quarto renders `.ipynb` files as-is:
+
+```bash
+quarto render notebook.ipynb
+quarto render notebook.ipynb --to pdf
+```
+
+Cell outputs stored in the notebook are used by default; set `execute: enabled: true` to force re-execution.
+
+## Converting Between Formats
+
+`quarto convert` works in both directions:
+
+```bash
+quarto convert notebook.ipynb   # → notebook.qmd
+quarto convert notebook.qmd     # → notebook.ipynb
+```
+
+Converting `.ipynb` → `.qmd`: extracts cell source into code blocks, converts markdown cells to prose, and discards stored outputs (Quarto re-executes on next render).
+
+Converting `.qmd` → `.ipynb`: produces a notebook with cells matching the `.qmd` structure, without executing them.
+
+## Key Differences: .ipynb vs .qmd
+
+| Feature         | .ipynb                 | .qmd                      |
+| --------------- | ---------------------- | ------------------------- |
+| Cell options    | Cell metadata JSON     | Hashpipe comments (`#\|`) |
+| Version control | JSON (noisy diffs)     | Plain text (clean diffs)  |
+| Edit experience | Jupyter UI             | Any text editor           |
+| Inline outputs  | Stored in file         | Re-computed on render     |
+
+## Cell Option Migration
+
+Jupyter cell metadata becomes hashpipe options in `.qmd`.
+
+**Before (.ipynb cell metadata):**
+
+```json
+{
+  "tags": ["remove-input"]
+}
+```
+
+**After (.qmd):**
+
+```
+#| echo: false
+```
+
+### Common Metadata Mappings
+
+Quarto options use the `#|` prefix in code cells.
+
+| Jupyter / nbconvert tag         | Quarto option      |
+| ------------------------------- | ------------------ |
+| `remove-input` / `hide-input`   | `echo: false`      |
+| `remove-output` / `hide-output` | `output: false`    |
+| `remove-cell`                   | `include: false`   |
+| `raises-exception`              | `error: true`      |
+
+## YAML Front Matter
+
+`.qmd` files use YAML front matter; `.ipynb` files use notebook-level metadata JSON.
+After converting `.ipynb` → `.qmd`, add YAML at the top:
+
+```yaml
+---
+title: "My Analysis"
+author: "Jane Doe"
+date: today
+format: html
+execute:
+  echo: true
+  warning: false
+jupyter: python3
+---
+```
+
+For engine and kernel selection, see [engines.md](engines.md).
+
+## Controlling Re-Execution
+
+For `.ipynb` files, Quarto uses stored cell outputs by default.
+For `.qmd` files, Quarto re-executes all cells on every render.
+
+To use stored outputs when rendering a `.qmd` (e.g. after `quarto convert`):
+
+```yaml
+execute:
+  enabled: false
+```
+
+To force re-execution of a `.ipynb`:
+
+```yaml
+execute:
+  enabled: true
+```
+
+For project-level caching and freeze, see [engines.md](engines.md).
+
+## When to Use Each Format
+
+Prefer `.qmd` when:
+
+- The document is under version control (clean diffs, no output blobs).
+- You want hashpipe options instead of JSON cell metadata.
+- You are working in any editor, not just Jupyter UI.
+
+Prefer `.ipynb` when:
+
+- The notebook is primarily interactive exploration.
+- It is shared with users who do not use Quarto.
+- It relies heavily on Jupyter widgets.
+
+## Resources
+
+- [Jupyter Kernel Execution](https://quarto.org/docs/advanced/jupyter/kernel-execution.html)
+- [Quarto convert CLI](https://quarto.org/docs/cli/convert.html)

--- a/quarto/quarto-authoring/references/cross-references.md
+++ b/quarto/quarto-authoring/references/cross-references.md
@@ -31,7 +31,7 @@ All cross-referenceable elements require a label starting with a type prefix:
 
 For consistency, prefer using div syntax for cross-referenceable elements:
 
-````markdown
+```markdown
 ::: {#tbl-example}
 
 | Column 1 | Column 2 |
@@ -40,17 +40,17 @@ For consistency, prefer using div syntax for cross-referenceable elements:
 
 Table caption.
 :::
-````
+```
 
 Instead of inline caption syntax:
 
-````markdown
+```markdown
 | Column 1 | Column 2 |
 | -------- | -------- |
 | Data     | Data     |
 
 : Table caption. {#tbl-example}
-````
+```
 
 Both syntaxes work, but div syntax provides a more consistent pattern across all element types (figures, tables, theorems, etc.).
 
@@ -58,48 +58,48 @@ Both syntaxes work, but div syntax provides a more consistent pattern across all
 
 Use `@` followed by the label to create a reference:
 
-````markdown
+```markdown
 See @fig-plot for the visualization.
 The data is shown in @tbl-results.
 As discussed in @sec-methods, we used...
-````
+```
 
 ### Capitalization
 
 Use capital letter to get capitalized prefix:
 
-````markdown
+```markdown
 @fig-plot → Figure 1
 @Fig-plot → Figure 1 (same, but ensures capital)
-````
+```
 
 ### Prefix Customization
 
 Use square brackets for custom prefix:
 
-````markdown
+```markdown
 [Figure @fig-plot] → Figure 1
 [See @fig-plot] → See 1
 [-@fig-plot] → 1 (number only)
-````
+```
 
 ### Multiple References
 
-````markdown
+```markdown
 See @fig-plot and @fig-scatter.
 Tables [-@tbl-one; -@tbl-two] show...
-````
+```
 
 ## Figures
 
 ### Code-Generated Figures
 
 ````markdown
-```{r}
+```{language}
 #| label: fig-scatter
 #| fig-cap: "Scatter plot of x versus y."
 
-plot(x, y)
+# code that produces a figure
 ```
 ````
 
@@ -107,15 +107,15 @@ Reference: `See @fig-scatter.`
 
 ### Markdown Figures
 
-````markdown
+```markdown
 ![Elephant](elephant.png){#fig-elephant}
 
 See @fig-elephant for the image.
-````
+```
 
 ### Subfigures
 
-````markdown
+```markdown
 ::: {#fig-animals layout-ncol=2}
 
 ![Cat](cat.png){#fig-cat}
@@ -126,18 +126,18 @@ Comparison of animals.
 :::
 
 See @fig-animals, specifically @fig-cat.
-````
+```
 
 ## Tables
 
 ### Code-Generated Tables
 
 ````markdown
-```{r}
+```{language}
 #| label: tbl-summary
 #| tbl-cap: "Summary statistics."
 
-knitr::kable(summary_data)
+# code that produces a table
 ```
 
 Reference: `See @tbl-summary.`
@@ -145,7 +145,7 @@ Reference: `See @tbl-summary.`
 
 ### Markdown Tables
 
-````markdown
+```markdown
 ::: {#tbl-data}
 
 | Col 1 | Col 2 |
@@ -156,11 +156,11 @@ Summary data.
 :::
 
 See @tbl-data for details.
-````
+```
 
 ### Subtables
 
-````markdown
+```markdown
 ::: {#tbl-panel layout-ncol=2}
 
 ::: {#tbl-first}
@@ -185,7 +185,7 @@ Combined tables.
 :::
 
 See @tbl-panel, including @tbl-first.
-````
+```
 
 ## Sections
 
@@ -197,26 +197,26 @@ number-sections: true
 
 Add label to heading:
 
-````markdown
+```markdown
 ## Introduction {#sec-intro}
 
 As discussed in @sec-intro...
-````
+```
 
 ## Equations
 
-````markdown
+```markdown
 $$
 y = mx + b
 $$ {#eq-line}
 
 Equation @eq-line shows...
 $$
-````
+```
 
 ## Theorems and Proofs
 
-````markdown
+```markdown
 ::: {#thm-pythagorean}
 
 ## Pythagorean Theorem
@@ -226,7 +226,7 @@ $$a^2 + b^2 = c^2$$
 :::
 
 By @thm-pythagorean, we know...
-````
+```
 
 Available theorem types: `thm`, `lem`, `cor`, `prp`, `cnj`, `def`, `exm`, `exr`.
 
@@ -245,7 +245,7 @@ See @lst-example for the code.
 
 Make callouts cross-referenceable by adding an ID:
 
-````markdown
+```markdown
 ::: {#nte-important .callout-note}
 
 ## Important Note
@@ -254,7 +254,7 @@ This is cross-referenceable.
 :::
 
 See @nte-important for details.
-````
+```
 
 ## Custom Cross-Reference Types
 
@@ -271,7 +271,7 @@ crossref:
 
 Use:
 
-````markdown
+```markdown
 ::: {#vid-demo}
 <video src="demo.mp4"></video>
 
@@ -279,7 +279,7 @@ Demo video.
 :::
 
 See @vid-demo.
-````
+```
 
 ## Cross-Reference Options
 
@@ -312,4 +312,3 @@ For bookdown migration details, see [conversion-bookdown.md](conversion-bookdown
 - [Quarto Cross-References](https://quarto.org/docs/authoring/cross-references.html)
 - [Figures](https://quarto.org/docs/authoring/figures.html)
 - [Tables](https://quarto.org/docs/authoring/tables.html)
-

--- a/quarto/quarto-authoring/references/engines.md
+++ b/quarto/quarto-authoring/references/engines.md
@@ -1,0 +1,125 @@
+# Compute Engines
+
+Quarto separates the authoring layer (YAML front matter, hashpipe options, cross-references, layouts) from the compute engine that executes code cells.
+All cell options, figure/table options, and cross-reference syntax are identical across engines.
+
+## Engine Overview
+
+| Engine    | Activated by                          | Primary language(s) | Notes                                               |
+| --------- | ------------------------------------- | ------------------- | --------------------------------------------------- |
+| `knitr`   | `{r}` cells                           | R                   | Default when R cells are present                    |
+| `julia`   | `{julia}` cells                       | Julia               | Default when Julia cells are present (Quarto 1.9+)  |
+| `jupyter` | `{python}` or any Jupyter kernel cell | Python, others      | Default for Python and other non-R, non-Julia cells |
+
+Since Quarto 1.9, engine extensions allow third-party engines to register additional language identifiers.
+The `{LANGUAGE}` cell surface and all hashpipe options remain the same regardless of the engine.
+
+## Auto-Detection
+
+Quarto picks the engine automatically from the first executable cell in the document:
+
+- First `{r}` cell → knitr engine.
+- First `{julia}` cell → julia engine (Quarto 1.9+).
+- First `{python}` or other non-R, non-Julia cell → jupyter engine.
+
+## Selecting an Engine Explicitly
+
+Override auto-detection in YAML front matter:
+
+```yaml
+engine: knitr
+```
+
+```yaml
+engine: jupyter
+jupyter: python3 # kernel name (default: python3)
+```
+
+```yaml
+engine: julia
+```
+
+The `jupyter` key accepts any installed kernel name:
+
+```yaml
+engine: jupyter
+jupyter: ir        # R via IRkernel
+jupyter: myenv     # named conda/venv kernel
+jupyter: julia-1.10
+```
+
+List available kernels with:
+
+```bash
+jupyter kernelspec list
+```
+
+## Hashpipe Comment Prefix
+
+The hashpipe comment prefix depends on the cell type:
+
+- R, Python, Julia: `#|`
+- Mermaid: `%%|`
+- Graphviz/DOT: `//|`
+
+## Engine-Specific Behaviour
+
+### Table Output
+
+**knitr engine**: Values returned from a cell that are recognised as table objects (e.g. data frames, matrices) are automatically rendered as markdown tables.
+
+**jupyter engine**: Cells returning a display-protocol object auto-display as HTML in HTML output only.
+For portable output across all formats, print a markdown string and use `output: asis`:
+
+````markdown
+```{language}
+#| tbl-cap: "Summary statistics."
+#| output: asis
+
+# print markdown table string to stdout
+```
+````
+
+### Inline Code
+
+Inline code syntax differs by engine:
+
+| Engine  | Inline syntax                                             |
+| ------- | --------------------------------------------------------- |
+| knitr   | `` `r expr` ``                                            |
+| jupyter | Not supported natively in `.qmd`; use cell output instead |
+| julia   | Not supported natively in `.qmd`; use cell output instead |
+
+### Caching
+
+Both knitr and jupyter engines support cell-level caching with `cache: true`.
+For project-level freeze (skip re-execution when source is unchanged):
+
+```yaml
+execute:
+  freeze: auto
+```
+
+## Engine Extensions (Quarto 1.9+)
+
+Third-party extensions can register custom engines via the Quarto extension system.
+Custom engines use the same `{LANGUAGE}` cell syntax and the same `#|` hashpipe options as built-in engines.
+Install engine extensions with:
+
+```bash
+quarto add <extension>
+```
+
+Then activate in YAML:
+
+```yaml
+engine: <extension-engine-name>
+```
+
+## Resources
+
+- [Using R](https://quarto.org/docs/computations/r.html)
+- [Using Python](https://quarto.org/docs/computations/python.html)
+- [Using Julia](https://quarto.org/docs/computations/julia.html)
+- [Execution Options](https://quarto.org/docs/computations/execution-options.html)
+- [Engine Extensions](https://quarto.org/docs/extensions/engine.html)

--- a/quarto/quarto-authoring/references/figures.md
+++ b/quarto/quarto-authoring/references/figures.md
@@ -6,23 +6,23 @@ Quarto provides comprehensive support for figures including sizing, layout, subf
 
 ### Markdown Images
 
-````markdown
+```markdown
 ![Caption text](image.png)
-````
+```
 
 ### With Attributes
 
-````markdown
+```markdown
 ![Caption text](image.png){width=50%}
-````
+```
 
 ### Cross-Referenceable Figure
 
-````markdown
+```markdown
 ![Caption text](image.png){#fig-example}
 
 See @fig-example.
-````
+```
 
 ## Figure Attributes
 
@@ -39,26 +39,26 @@ Common attributes for images:
 
 Multiple units supported:
 
-````markdown
+```markdown
 ![](image.png){width=50%}
 ![](image.png){width=400px}
 ![](image.png){width=4in}
 ![](image.png){width=10cm}
-````
+```
 
 ### Alignment
 
-````markdown
+```markdown
 ![Left aligned](image.png){fig-align="left"}
 ![Centered](image.png){fig-align="center"}
 ![Right aligned](image.png){fig-align="right"}
-````
+```
 
 ### Alt Text for Accessibility
 
-````markdown
+```markdown
 ![Caption](image.png){fig-alt="Detailed description for screen readers"}
-````
+```
 
 Alt text differs from caption - it describes the image content for accessibility.
 
@@ -67,7 +67,7 @@ Alt text differs from caption - it describes the image content for accessibility
 Figures generated from code use hashpipe options:
 
 ````markdown
-```{r}
+```{language}
 #| label: fig-scatter
 #| fig-cap: "Scatter plot showing the relationship."
 #| fig-alt: "Scatter plot with positive trend."
@@ -75,22 +75,7 @@ Figures generated from code use hashpipe options:
 #| fig-height: 6
 #| fig-align: center
 
-plot(x, y)
-```
-````
-
-### Python Example
-
-````markdown
-```{python}
-#| label: fig-histogram
-#| fig-cap: "Distribution of values."
-#| fig-width: 10
-#| fig-height: 6
-
-import matplotlib.pyplot as plt
-plt.hist(data, bins=30)
-plt.show()
+# code that produces a figure
 ```
 ````
 
@@ -112,7 +97,7 @@ plt.show()
 
 Group multiple images with a shared caption:
 
-````markdown
+```markdown
 ::: {#fig-comparison layout-ncol=2}
 
 ![First image](image1.png){#fig-first}
@@ -123,12 +108,12 @@ Comparison of two approaches.
 :::
 
 See @fig-comparison, particularly @fig-first.
-````
+```
 
 ### From Code
 
 ````markdown
-```{r}
+```{language}
 #| label: fig-panels
 #| fig-cap: "Panel figure."
 #| fig-subcap:
@@ -136,8 +121,7 @@ See @fig-comparison, particularly @fig-first.
 #|   - "Distribution of Y"
 #| layout-ncol: 2
 
-hist(x)
-hist(y)
+# code that produces two figures (one per panel)
 ```
 ````
 
@@ -147,28 +131,28 @@ For arranging multiple figures, use layout divs. See [layout.md](layout.md) for 
 
 ### Basic Layout
 
-````markdown
+```markdown
 ::: {layout-ncol=2}
 ![](image1.png)
 
 ![](image2.png)
 :::
-````
+```
 
 ### Layout Attributes
 
-| Attribute        | Description           | Example             |
-| ---------------- | --------------------- | ------------------- |
-| `layout-ncol`    | Number of columns     | `layout-ncol=2`     |
-| `layout-nrow`    | Number of rows        | `layout-nrow=2`     |
-| `layout`         | Custom layout array   | `layout="[[1,1]]"`  |
-| `layout-valign`  | Vertical alignment    | `layout-valign=top` |
+| Attribute       | Description         | Example             |
+| --------------- | ------------------- | ------------------- |
+| `layout-ncol`   | Number of columns   | `layout-ncol=2`     |
+| `layout-nrow`   | Number of rows      | `layout-nrow=2`     |
+| `layout`        | Custom layout array | `layout="[[1,1]]"`  |
+| `layout-valign` | Vertical alignment  | `layout-valign=top` |
 
 ## Figure Panels
 
 For images without individual captions:
 
-````markdown
+```markdown
 ::: {#fig-panel layout-ncol=2}
 ![](plot1.png)
 
@@ -176,7 +160,7 @@ For images without individual captions:
 
 Multiple plots in a panel.
 :::
-````
+```
 
 ## Caption Location
 
@@ -189,12 +173,12 @@ fig-cap-location: top
 ### Per Figure
 
 ````markdown
-```{r}
+```{language}
 #| label: fig-example
 #| fig-cap: "Caption on top."
 #| fig-cap-location: top
 
-plot(1:10)
+# code that produces a figure
 ```
 ````
 
@@ -204,25 +188,25 @@ Options: `top`, `bottom`, `margin`.
 
 Enable click-to-zoom for images (HTML only):
 
-````markdown
+```markdown
 ![](image.png){.lightbox}
-````
+```
 
 Or for a group:
 
-````markdown
+```markdown
 ::: {.lightbox}
 ![](image1.png)
 
 ![](image2.png)
 :::
-````
+```
 
 ### Lightbox Options
 
-````markdown
+```markdown
 ![](image.png){.lightbox group="gallery" description="Detailed view"}
-````
+```
 
 ### Enable Globally
 
@@ -243,28 +227,28 @@ lightbox:
 
 Make images clickable:
 
-````markdown
+```markdown
 [![Caption](thumbnail.png)](fullsize.png)
-````
+```
 
 Or link to URL:
 
-````markdown
+```markdown
 [![Logo](logo.png)](https://example.com)
-````
+```
 
 ## Figure Divs
 
 For complex figure content:
 
-````markdown
+```markdown
 ::: {#fig-custom}
 
 <iframe src="interactive.html"></iframe>
 
 Custom interactive figure.
 :::
-````
+```
 
 ## Document Defaults
 
@@ -285,4 +269,3 @@ format:
 - [Quarto Figures](https://quarto.org/docs/authoring/figures.html)
 - [Figure Layout](https://quarto.org/docs/authoring/figures.html#figure-panels)
 - [Lightbox](https://quarto.org/docs/output-formats/html-lightbox-figures.html)
-

--- a/quarto/quarto-authoring/references/layout.md
+++ b/quarto/quarto-authoring/references/layout.md
@@ -20,67 +20,67 @@ Quarto provides column classes for controlling content width and placement, incl
 
 Standard content width:
 
-````markdown
+```markdown
 ::: {.column-body}
 Default body-width content.
 :::
-````
+```
 
 ### Body Outset
 
 Slightly wider than body:
 
-````markdown
+```markdown
 ::: {.column-body-outset}
 ![Wide image](wide.png)
 :::
-````
+```
 
 ### Page Width
 
 Extends to page margins:
 
-````markdown
+```markdown
 ::: {.column-page}
 ![Page-width image](panorama.png)
 :::
-````
+```
 
 ### Screen Width
 
 Full browser width (no margins):
 
-````markdown
+```markdown
 ::: {.column-screen}
 ![Full-width image](banner.png)
 :::
-````
+```
 
 ### Screen Inset
 
 Full width with small margins:
 
-````markdown
+```markdown
 ::: {.column-screen-inset}
 Content with small margins.
 :::
-````
+```
 
 ### Shaded Screen Inset
 
 With background shading:
 
-````markdown
+```markdown
 ::: {.column-screen-inset-shaded}
 Shaded full-width content.
 :::
-````
+```
 
 ## Directional Variants
 
 Each column class has left/right variants:
 
-````markdown
+```markdown
 ::: {.column-body-outset-left}
 Extends left only.
 :::
@@ -92,51 +92,51 @@ Extends to right page margin.
 ::: {.column-screen-left}
 Full width on left side.
 :::
-````
+```
 
 ## Margin Content
 
 ### Text in Margin
 
-````markdown
+```markdown
 ::: {.column-margin}
 This appears in the right margin.
 :::
-````
+```
 
 ### Figures in Margin
 
 ````markdown
-```{r}
+```{language}
 #| column: margin
 #| fig-cap: "Margin figure."
 
-plot(1:10)
+# code that produces a figure
 ```
 ````
 
 Or for markdown images:
 
-````markdown
+```markdown
 ::: {.column-margin}
 ![Margin image](small.png)
 :::
-````
+```
 
 ### Tables in Margin
 
 ````markdown
-```{r}
+```{language}
 #| column: margin
 #| tbl-cap: "Margin table."
 
-knitr::kable(small_data)
+# code that produces a table
 ```
 ````
 
 ### Mixed Content
 
-````markdown
+`````markdown
 Main text here.
 
 ::: {.column-margin}
@@ -144,7 +144,8 @@ Margin note explaining the main content.
 :::
 
 More main text.
-```
+
+`````
 
 ## Code Cell Layout Options
 
@@ -153,11 +154,10 @@ Control output placement from code cells:
 ### Column Option
 
 ````markdown
-```{r}
+```{language}
 #| column: page
 
-# Output spans page width
-plot(1:100)
+# output spans page width
 ```
 ````
 
@@ -168,10 +168,10 @@ Options: `body`, `body-outset`, `page`, `page-inset`, `screen`, `screen-inset`, 
 Target figure outputs specifically:
 
 ````markdown
-```{r}
+```{language}
 #| fig-column: margin
 
-plot(1:10)
+# code that produces a figure
 ```
 ````
 
@@ -180,10 +180,10 @@ plot(1:10)
 Target table outputs:
 
 ````markdown
-```{r}
+```{language}
 #| tbl-column: page
 
-knitr::kable(wide_data)
+# code that produces a wide table
 ```
 ````
 
@@ -192,11 +192,11 @@ knitr::kable(wide_data)
 ### In Margin
 
 ````markdown
-```{r}
+```{language}
 #| fig-cap: "Figure with margin caption."
 #| cap-location: margin
 
-plot(1:10)
+# code that produces a figure
 ```
 ````
 
@@ -256,7 +256,7 @@ format:
 
 Create side-by-side columns:
 
-````markdown
+```markdown
 ::: {.columns}
 
 ::: {.column width="50%"}
@@ -268,7 +268,7 @@ Right column content.
 :::
 
 :::
-````
+```
 
 Adjust `width` percentages for unequal columns (e.g., `30%`/`70%`).
 
@@ -278,29 +278,29 @@ Arrange any content (images, tables, text) in grid layouts.
 
 ### Column Layout
 
-````markdown
+```markdown
 ::: {layout-ncol=2}
 ![](image1.png)
 
 ![](image2.png)
 :::
-````
+```
 
 ### Row Layout
 
-````markdown
+```markdown
 ::: {layout-nrow=2}
 Content 1.
 
 Content 2.
 :::
-````
+```
 
 ### Complex Layouts
 
 Use layout array for precise control. Values represent relative widths:
 
-````markdown
+```markdown
 ::: {layout="[[1,1], [1]]"}
 First row, left.
 
@@ -308,13 +308,13 @@ First row, right.
 
 Second row, full width.
 :::
-````
+```
 
 ### With Spacing
 
 Negative values add spacing between elements:
 
-````markdown
+```markdown
 ::: {layout="[[40,-20,40], [100]]"}
 Content 1.
 
@@ -322,34 +322,34 @@ Content 2.
 
 Full width below.
 :::
-````
+```
 
 ### Vertical Alignment
 
-````markdown
+```markdown
 ::: {layout-ncol=2 layout-valign="bottom"}
 Tall content.
 
 Short content.
 :::
-````
+```
 
 Options: `top`, `center`, `bottom`.
 
 ### Layout Attributes
 
-| Attribute       | Description            | Example                |
-| --------------- | ---------------------- | ---------------------- |
-| `layout-ncol`   | Number of columns      | `layout-ncol=3`        |
-| `layout-nrow`   | Number of rows         | `layout-nrow=2`        |
-| `layout`        | Custom layout array    | `layout="[[1,2],[1]]"` |
-| `layout-valign` | Vertical alignment     | `layout-valign=center` |
+| Attribute       | Description         | Example                |
+| --------------- | ------------------- | ---------------------- |
+| `layout-ncol`   | Number of columns   | `layout-ncol=3`        |
+| `layout-nrow`   | Number of rows      | `layout-nrow=2`        |
+| `layout`        | Custom layout array | `layout="[[1,2],[1]]"` |
+| `layout-valign` | Vertical alignment  | `layout-valign=center` |
 
 ## Tabsets
 
 Create tabbed content:
 
-````markdown
+```markdown
 ::: {.panel-tabset}
 
 ## Tab 1
@@ -361,7 +361,7 @@ Content for tab 1.
 Content for tab 2.
 
 :::
-````
+```
 
 ### With Groups
 
@@ -381,7 +381,6 @@ x = 1
 ```
 
 :::
-
 ````
 
 Tabs with same group stay synchronized.
@@ -390,11 +389,11 @@ Tabs with same group stay synchronized.
 
 For inline margin notes:
 
-````markdown
+```markdown
 Main text content.
 [This is an aside that appears in the margin.]{.aside}
 More main text.
-````
+```
 
 ## PDF Layout
 
@@ -425,5 +424,3 @@ KOMA classes support margin content automatically.
 - [Quarto Article Layout](https://quarto.org/docs/authoring/article-layout.html)
 - [Page Layout](https://quarto.org/docs/output-formats/page-layout.html)
 - [Figures Layout](https://quarto.org/docs/authoring/figures.html#figure-panels)
-
-

--- a/quarto/quarto-authoring/references/markdown-linting.md
+++ b/quarto/quarto-authoring/references/markdown-linting.md
@@ -21,7 +21,7 @@ Quarto documents may have multiple H1 headers, especially in books and multi-par
 Quarto uses HTML in specific contexts:
 
 - Shortcodes: `{{< shortcode >}}`
-- Raw HTML blocks: `` ```{=html} ``
+- Raw HTML blocks: ` ```{=html} `
 - Elements like `<div>`, `<span>`, `<iframe>` for advanced layouts
 
 ### First Line H1 (MD041)
@@ -65,7 +65,7 @@ globs:
 
 When using fenced divs, ensure proper blank-line spacing:
 
-````markdown
+```markdown
 Some text.
 
 ::: {.callout-note}
@@ -73,13 +73,12 @@ Note content here.
 :::
 
 More text.
-````
+```
 
 Key points:
 
 - Blank line before opening `:::`.
 - Blank line after closing `:::`.
-- Use `::::` (four+ colons) for nesting outer divs.
 
 ## Resources
 

--- a/quarto/quarto-authoring/references/tables.md
+++ b/quarto/quarto-authoring/references/tables.md
@@ -6,23 +6,23 @@ Quarto supports multiple table formats including pipe tables, list tables, and c
 
 The most common table format:
 
-````markdown
+```markdown
 | Column 1 | Column 2 | Column 3 |
 | -------- | -------- | -------- |
 | Row 1    | Data     | More     |
 | Row 2    | Data     | More     |
-````
+```
 
 ### Column Alignment
 
 Use colons to specify alignment:
 
-````markdown
+```markdown
 | Left    | Center  |   Right |
 | :------ | :-----: | ------: |
 | Left    | Center  |   Right |
 | aligned | aligned | aligned |
-````
+```
 
 - `:---` Left align
 - `:---:` Center align
@@ -30,7 +30,7 @@ Use colons to specify alignment:
 
 ### With Caption
 
-````markdown
+```markdown
 ::: {#tbl-example}
 
 | Column 1 | Column 2 |
@@ -39,7 +39,7 @@ Use colons to specify alignment:
 
 Table caption.
 :::
-````
+```
 
 Reference with `@tbl-example`.
 
@@ -49,23 +49,23 @@ Reference with `@tbl-example`.
 
 More dashes = wider column:
 
-````markdown
+```markdown
 | Narrow | Wide Column |
 | ------ | ----------- |
 | A      | B           |
-````
+```
 
 This creates approximately 33%/67% split.
 
 ### Explicit Widths
 
-````markdown
+```markdown
 | Column 1 | Column 2 |
 | -------- | -------- |
 | Data     | Data     |
 
 : Caption {tbl-colwidths="[25,75]"}
-````
+```
 
 ### Document Level
 
@@ -87,7 +87,7 @@ For complex content including multiple paragraphs, lists, and code blocks. Quart
 
 Use bullet lists where top-level items (`-`) are columns and nested items are rows:
 
-````markdown
+```markdown
 ::: {.list-table}
 
 - - Header 1
@@ -98,13 +98,13 @@ Use bullet lists where top-level items (`-`) are columns and nested items are ro
   - Row 2, Col 2
 
 :::
-````
+```
 
 ### List Table Caption
 
 Add a paragraph at the start for the caption:
 
-````markdown
+```markdown
 ::: {.list-table #tbl-example}
 
 Table caption here.
@@ -117,23 +117,23 @@ Table caption here.
   - Data 3
 
 :::
-````
+```
 
 ### List Table Attributes
 
-| Attribute     | Description                  | Example                |
-| ------------- | ---------------------------- | ---------------------- |
-| `header-rows` | Rows in header (default: 1)  | `header-rows=2`        |
-| `header-cols` | Columns as headers           | `header-cols=1`        |
-| `aligns`      | Column alignment             | `aligns="l,c,r"`       |
-| `widths`      | Relative column widths       | `widths="30,70"`       |
+| Attribute     | Description                 | Example          |
+| ------------- | --------------------------- | ---------------- |
+| `header-rows` | Rows in header (default: 1) | `header-rows=2`  |
+| `header-cols` | Columns as headers          | `header-cols=1`  |
+| `aligns`      | Column alignment            | `aligns="l,c,r"` |
+| `widths`      | Relative column widths      | `widths="30,70"` |
 
 ### Header Configuration
 
-````markdown
+```markdown
 ::: {.list-table header-rows=1 header-cols=1}
 
-- - 
+- -
   - Col Header 1
   - Col Header 2
 - - Row Header
@@ -141,7 +141,7 @@ Table caption here.
   - Data 2
 
 :::
-````
+```
 
 Set `header-rows=0` for tables without headers.
 
@@ -149,7 +149,7 @@ Set `header-rows=0` for tables without headers.
 
 Use empty spans with `colspan` or `rowspan`:
 
-````markdown
+```markdown
 ::: {.list-table}
 
 - - Column A
@@ -167,7 +167,7 @@ Use empty spans with `colspan` or `rowspan`:
   - Data 4
 
 :::
-````
+```
 
 List tables also support row/cell attributes (`[]{.highlight}`, `[]{align=r}`), empty cells (lone `-`), and any markdown content in cells.
 
@@ -175,41 +175,31 @@ List tables also support row/cell attributes (`[]{.highlight}`, `[]{align=r}`), 
 
 Tables generated from code:
 
-### R with knitr
-
 ````markdown
-```{r}
+```{language}
 #| label: tbl-summary
 #| tbl-cap: "Summary statistics."
 
-knitr::kable(summary_data)
+# code that produces a table
 ```
 ````
 
-### R with gt
+**Engine note — table rendering differs by engine:**
+
+- **knitr engine**: Recognised table objects are rendered automatically (e.g. a data frame is printed as a markdown table without extra configuration).
+- **jupyter engine**: Cells that return a display-protocol object auto-display as HTML in HTML output only. For portable output across all formats, print a markdown table string and set `output: asis`:
 
 ````markdown
-```{r}
-#| label: tbl-styled
-#| tbl-cap: "Styled table."
+```{language}
+#| label: tbl-summary
+#| tbl-cap: "Summary statistics."
+#| output: asis
 
-library(gt)
-gt(data) |>
-  tab_header(title = "My Table")
+# print a markdown table string to stdout
 ```
 ````
 
-### Python with pandas
-
-````markdown
-```{python}
-#| label: tbl-pandas
-#| tbl-cap: "Data summary."
-
-import pandas as pd
-df.to_markdown()
-```
-````
+See [engines.md](engines.md) for full engine details.
 
 ### Table Options
 
@@ -231,12 +221,12 @@ tbl-cap-location: top
 ### Per Table
 
 ````markdown
-```{r}
+```{language}
 #| label: tbl-data
 #| tbl-cap: "Data."
 #| tbl-cap-location: bottom
 
-knitr::kable(data)
+# code that produces a table
 ```
 ````
 
@@ -246,7 +236,7 @@ Options: `top`, `bottom`, `margin`.
 
 Multiple tables with shared caption:
 
-````markdown
+```markdown
 ::: {#tbl-panel layout-ncol=2}
 
 ::: {#tbl-first}
@@ -271,12 +261,12 @@ Combined tables.
 :::
 
 See @tbl-panel, including @tbl-first.
-````
+```
 
 ### From Code
 
 ````markdown
-```{r}
+```{language}
 #| label: tbl-multi
 #| tbl-cap: "Multiple tables."
 #| tbl-subcap:
@@ -284,8 +274,7 @@ See @tbl-panel, including @tbl-first.
 #|   - "Details"
 #| layout-ncol: 2
 
-knitr::kable(summary_df)
-knitr::kable(detail_df)
+# code that produces two tables
 ```
 ````
 
@@ -293,7 +282,7 @@ knitr::kable(detail_df)
 
 Add Bootstrap classes for styling:
 
-````markdown
+```markdown
 ::: {#tbl-styled .striped .hover}
 
 | A   | B   |
@@ -302,7 +291,7 @@ Add Bootstrap classes for styling:
 
 Styled table.
 :::
-````
+```
 
 Available classes:
 
@@ -323,7 +312,7 @@ Quarto also processes HTML tables with `data-qmd` attribute for markdown content
 
 Same as figures:
 
-````markdown
+```markdown
 ::: {layout-ncol=2}
 
 | A   | B   |
@@ -335,26 +324,17 @@ Same as figures:
 | 3   | 4   |
 
 :::
-````
+```
 
 ## Long Tables
 
-For tables spanning multiple pages (PDF):
-
-````markdown
-```{r}
-#| label: tbl-long
-#| tbl-cap: "Long table."
-
-knitr::kable(long_data, longtable = TRUE)
-```
-````
+For tables spanning multiple pages (PDF), use a longtable option appropriate to your engine/package.
 
 ## Cross-Referencing
 
 Tables are referenced with `tbl-` prefix:
 
-````markdown
+```markdown
 ::: {#tbl-summary}
 
 | Data |
@@ -365,11 +345,10 @@ Summary.
 :::
 
 See @tbl-summary for details.
-````
+```
 
 ## Resources
 
 - [Quarto Tables](https://quarto.org/docs/authoring/tables.html)
 - [Table Cross-References](https://quarto.org/docs/authoring/cross-references.html#tables)
 - [Pandoc List Tables](https://github.com/pandoc-ext/list-table)
-

--- a/quarto/quarto-authoring/references/yaml-front-matter.md
+++ b/quarto/quarto-authoring/references/yaml-front-matter.md
@@ -373,10 +373,10 @@ params:
 Use in document:
 
 ````markdown
-```{r}
+```{language}
 #| label: read-data
 
-data <- read.csv(params$data_file)
+# access params$data_file (knitr) or params["data_file"] (jupyter) etc.
 ```
 ````
 
@@ -411,9 +411,13 @@ format:
     theme: cosmo
 ```
 
+## Compute Engine
+
+Use the `engine` and `jupyter` keys to select and configure the compute engine.
+See [engines.md](engines.md) for options, auto-detection rules, and engine-specific behaviour.
+
 ## Resources
 
 - [Quarto Document Options](https://quarto.org/docs/reference/formats/html.html)
 - [PDF Options](https://quarto.org/docs/reference/formats/pdf.html)
 - [Project Configuration](https://quarto.org/docs/projects/quarto-projects.html)
-


### PR DESCRIPTION
## Changes

- Replace all `{r}` and `{python}` code cell examples with a `{language}` placeholder and pseudocode throughout the skill.
  Quarto's authoring layer (hashpipe options, cross-references, YAML metadata, layouts) is identical across all engines.
- Add `references/engines.md`: engine selection, auto-detection, hashpipe prefix per engine, and engine-specific behaviour differences (knitr auto-renders table objects; jupyter requires `output: asis` for portable markdown output).
- Add `references/conversion-jupyter.md`: bidirectional `quarto convert` (`.ipynb` ↔ `.qmd`) and format preference guidance.
- Add `output: asis` explainer to `references/code-cells.md`: what it does, requirements, and the `tbl-cap` caveat.
- Fix caching guidance in `references/code-cells.md` and `SKILL.md`: `#| cache: true` at cell level is knitr-only and is silently ignored by the jupyter and julia engines.
  Non-knitr engines use document-level `execute: cache: true` (requires `pip install jupyter-cache`).
  A blockquote warning makes this unambiguous at the top of the Caching section.
- Update SKILL.md description with fuller keyword surface (named engines, `.ipynb` trigger) to improve skill triggering coverage.
- DRY: `yaml-front-matter.md`, `code-cells.md`, and `conversion-jupyter.md` reference `engines.md` instead of repeating engine configuration content.
- Bump skill version to `1.4`, update Quarto CLI version note to `v1.9.36`.

## Benchmark

Three evals were run against the updated skill vs no skill (iteration 3):

| Eval | Topic | With skill | Without skill |
|------|-------|-----------|--------------|
| cache-regression | `cache: true` is knitr-only; jupyter uses `execute: cache: true` | 4/4 | 2/4 |
| julia-crossref | Cross-referencing Julia figures | 5/5 | 4/5 |
| output-asis | `output: asis` mechanics and `tbl-cap` caveat | 4/4 | 2/4 |
| **Overall** | | **100%** | **60%** |

The caching eval is the key regression test: without the skill, the model incorrectly recommends `#| cache: true` on Python cells (it is silently ignored); with the skill, it correctly directs users to document-level `execute: cache: true` and `pip install jupyter-cache`.

Supersedes #44