### PR TITLE
fix(pr-threads): require --pr and --repo on every gh pr-review call

### DIFF
--- a/github/pr-threads-address/SKILL.md
+++ b/github/pr-threads-address/SKILL.md
@@ -22,7 +22,7 @@ gh extension list | grep -q pr-review || gh extension install agynio/gh-pr-revie
 
 Every `gh pr-review` subcommand requires both `--pr <number>` and `--repo <owner/repo>` — do not omit either. Look the values up once at the start of the workflow and substitute the literal numbers and slugs into every later command.
 
-If the user did not pass `PR_NUMBER`, get it from the current branch:
+Get the PR number for the current branch:
 
 ```bash
 gh pr view --json number -q .number
@@ -54,12 +54,12 @@ Use this command when you have received PR review feedback and need to systemati
 ## Example
 
 ```
-/pr-threads-address 42
+/pr-threads-address
 ```
 
 This will:
 
-- View unresolved threads on PR #42
+- View unresolved threads on the PR for the current branch
 - Make code changes to address each thread
 - Create commits for the changes
 - Reply to reviewers with explanations

--- a/github/pr-threads-address/SKILL.md
+++ b/github/pr-threads-address/SKILL.md
@@ -47,25 +47,6 @@ Then pass the resulting values directly — e.g. `--pr 42 --repo posit-dev/skill
 4. Report back with a summary of addressed threads
 5. Ask if the user wants to resolve the threads. If so, reply to each thread indicating what was done and then resolve the thread.
 
-## When to use
-
-Use this command when you have received PR review feedback and need to systematically address all unresolved threads before the PR can be merged.
-
-## Example
-
-```
-/pr-threads-address
-```
-
-This will:
-
-- View unresolved threads on the PR for the current branch
-- Make code changes to address each thread
-- Create commits for the changes
-- Reply to reviewers with explanations
-- Provide a summary of all addressed items
-- Ask if you want to resolve the threads
-
 ## CLI Reference
 
 ### View PR Reviews and Comments
@@ -79,46 +60,21 @@ gh pr-review review view --pr <number> --repo <owner/repo>
 **Common filters:**
 
 - `--reviewer <login>` — Filter by specific reviewer
-- `--states <list>` — Filter by review state (APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED)
+- `--states <list>` — Comma-separated review states (APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED)
 - `--unresolved` — Show only unresolved threads
 - `--not_outdated` — Exclude outdated threads
 - `--tail <n>` — Show only the last n replies per thread
 - `--include-comment-node-id` — Include GraphQL node IDs for replies
 
-**Examples:**
-
-```bash
-# View all unresolved comments
-gh pr-review review view --pr 42 --unresolved --repo owner/repo
-
-# View comments from a specific reviewer
-gh pr-review review view --pr 42 --reviewer username --repo owner/repo
-
-# View only change requests, excluding outdated threads
-gh pr-review review view --pr 42 --states CHANGES_REQUESTED --not_outdated --repo owner/repo
-```
+Combine `--unresolved --not_outdated` to focus on actionable threads.
 
 ### Reply to Review Threads
-
-Respond to specific review comment threads:
 
 ```bash
 gh pr-review comments reply --thread-id <PRRT_...> --body "<reply-text>" --repo <owner/repo> --pr <number>
 ```
 
-**Multi-line replies** use heredoc syntax:
-
-```bash
-gh pr-review comments reply --thread-id PRRT_xyz789 --body "$(cat <<'EOF'
-Fixed in commit abc123.
-
-The changes include:
-- Updated function signature
-- Added error handling
-- Updated tests
-EOF
-)" --repo owner/repo --pr 42
-```
+For multi-line replies, pass `--body "$(cat <<'EOF' ... EOF\n)"` heredoc syntax.
 
 ### Resolve a Thread
 
@@ -126,53 +82,4 @@ EOF
 gh pr-review threads resolve --thread-id <PRRT_...> --pr <number> --repo <owner/repo>
 ```
 
-### Start a Pending Review
-
-Create a new pending review to add comments before submission:
-
-```bash
-gh pr-review review --start --pr <number> --repo <owner/repo>
-```
-
-This returns a review ID (format: `PRR_...`) needed for adding comments.
-
-### Add Review Comments
-
-Add inline comments to a pending review:
-
-```bash
-gh pr-review review --add-comment --review-id <PRR_...> --path <file-path> --line <number> --body "<comment-text>" --repo <owner/repo>
-```
-
-**Flags:**
-
-- `--review-id` — Review ID from `--start` command (required)
-- `--path` — File path in the repository (required)
-- `--line` — Line number for the comment (required)
-- `--body` — Comment text (required)
-
-### Submit a Review
-
-Finalize and submit a pending review:
-
-```bash
-gh pr-review review --submit --review-id <PRR_...> --event <EVENT_TYPE> --body "<summary>" --repo <owner/repo>
-```
-
-**Event types:**
-
-- `APPROVE` — Approve the changes
-- `REQUEST_CHANGES` — Request changes before merging
-- `COMMENT` — Submit general feedback without explicit approval
-
-## Usage Notes
-
-1. **Required flags**: Every `gh pr-review` subcommand (`review view`, `comments reply`, `threads list`, `threads resolve`, `review --start`, `review --add-comment`, `review --submit`, etc.) requires both `--pr <number>` and `--repo <owner/repo>`. Resolve them once at the start of the workflow and reuse on every call — do not drop them in loops or per-thread reply commands.
-
-2. **Thread IDs**: Thread IDs (format `PRRT_...`) can be obtained from `review view --include-comment-node-id` or `threads list` commands.
-
-3. **Review IDs**: Review IDs (format `PRR_...`) are returned by the `review --start` command and must be used for adding comments to that review.
-
-4. **State Filters**: When using `--states`, provide a comma-separated list: `--states APPROVED,CHANGES_REQUESTED`
-
-5. **Unresolved Focus**: Use `--unresolved --not_outdated` together to focus on actionable comments that need attention.
+Thread IDs (format `PRRT_...`) come from `review view --include-comment-node-id`.

--- a/github/pr-threads-address/SKILL.md
+++ b/github/pr-threads-address/SKILL.md
@@ -8,15 +8,17 @@ metadata:
 license: MIT
 ---
 
-# /pr-threads-address
+## Prerequisites
 
-**Usage:** `/pr-threads-address [PR_NUMBER]`
+### gh pr-review extension
 
-**Description:** Review all unresolved PR review threads, address them by making necessary code changes, and commit the changes appropriately.
+Before using this command, check if the gh pr-review extension is installed:
 
-**Note:** If `PR_NUMBER` is omitted, the command will automatically detect and use the PR associated with the current branch.
+```bash
+gh extension list | grep -q pr-review || gh extension install agynio/gh-pr-review
+```
 
-## Resolve PR context first
+### Resolve PR context
 
 Before running any `gh pr-review` subcommand, resolve the PR number and repo once and reuse them. Every `gh pr-review` subcommand requires both `--pr <number>` and `--repo <owner/repo>` — do not omit either.
 
@@ -29,15 +31,14 @@ Pass `--pr "$PR_NUMBER" --repo "$REPO"` on every subsequent `gh pr-review` call 
 
 ## Workflow
 
-1. Resolve `PR_NUMBER` and `REPO` as shown above
-2. Fetch and display all unresolved PR review threads
-3. Analyze each thread to understand the requested changes
-4. For each thread:
+1. Fetch and display all unresolved PR review threads
+2. Analyze each thread to understand the requested changes
+3. For each thread:
    1. Make the necessary code modifications
    2. (When possible) Add unit tests to verify the change
    3. Commit the changes with descriptive commit messages using conventional commit specification
-5. Report back with a summary of addressed threads
-6. Ask if the user wants to resolve the threads. If so, reply to each thread indicating what was done and then resolve the thread.
+4. Report back with a summary of addressed threads
+5. Ask if the user wants to resolve the threads. If so, reply to each thread indicating what was done and then resolve the thread.
 
 ## When to use
 
@@ -50,20 +51,13 @@ Use this command when you have received PR review feedback and need to systemati
 ```
 
 This will:
+
 - View unresolved threads on PR #42
 - Make code changes to address each thread
 - Create commits for the changes
 - Reply to reviewers with explanations
 - Provide a summary of all addressed items
 - Ask if you want to resolve the threads
-
-## Prerequisites
-
-Before using this command, check if the gh pr-review extension is installed:
-
-```bash
-gh extension list | grep -q pr-review || gh extension install agynio/gh-pr-review
-```
 
 ## CLI Reference
 

--- a/github/pr-threads-address/SKILL.md
+++ b/github/pr-threads-address/SKILL.md
@@ -62,11 +62,8 @@ gh pr-review review view --pr <number> --repo <owner/repo>
 - `--reviewer <login>` — Filter by specific reviewer
 - `--states <list>` — Comma-separated review states (APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED)
 - `--unresolved` — Show only unresolved threads
-- `--not_outdated` — Exclude outdated threads
 - `--tail <n>` — Show only the last n replies per thread
 - `--include-comment-node-id` — Include GraphQL node IDs for replies
-
-Combine `--unresolved --not_outdated` to focus on actionable threads.
 
 ### Reply to Review Threads
 

--- a/github/pr-threads-address/SKILL.md
+++ b/github/pr-threads-address/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-threads-address
-description: Review all unresolved PR review threads, address them by making necessary code changes, and commit the changes appropriately.
+description: "Address PR review feedback by systematically working through every unresolved PR review thread on the current branch's PR - analyze each comment, make the requested code changes (with tests where useful), commit, and optionally reply and resolve."
 compatibility: Designed for Claude Code; requires gh CLI and gh-pr-review extension
 metadata:
   author: Barret Schloerke (@schloerke)

--- a/github/pr-threads-address/SKILL.md
+++ b/github/pr-threads-address/SKILL.md
@@ -16,16 +16,28 @@ license: MIT
 
 **Note:** If `PR_NUMBER` is omitted, the command will automatically detect and use the PR associated with the current branch.
 
+## Resolve PR context first
+
+Before running any `gh pr-review` subcommand, resolve the PR number and repo once and reuse them. Every `gh pr-review` subcommand requires both `--pr <number>` and `--repo <owner/repo>` — do not omit either.
+
+```bash
+PR_NUMBER="${1:-$(gh pr view --json number -q .number)}"
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+```
+
+Pass `--pr "$PR_NUMBER" --repo "$REPO"` on every subsequent `gh pr-review` call in this workflow (review view, comments reply, threads resolve, etc.).
+
 ## Workflow
 
-1. Fetch and display all unresolved PR review threads
-2. Analyze each thread to understand the requested changes
-3. For each thread:
+1. Resolve `PR_NUMBER` and `REPO` as shown above
+2. Fetch and display all unresolved PR review threads
+3. Analyze each thread to understand the requested changes
+4. For each thread:
    1. Make the necessary code modifications
    2. (When possible) Add unit tests to verify the change
    3. Commit the changes with descriptive commit messages using conventional commit specification
-4. Report back with a summary of addressed threads
-5. Ask if the user wants to resolve the threads. If so, reply to each thread indicating what was done and then resolve the thread.
+5. Report back with a summary of addressed threads
+6. Ask if the user wants to resolve the threads. If so, reply to each thread indicating what was done and then resolve the thread.
 
 ## When to use
 
@@ -154,7 +166,7 @@ gh pr-review review --submit --review-id <PRR_...> --event <EVENT_TYPE> --body "
 
 ## Usage Notes
 
-1. **Repository Context**: Always include `--repo owner/repo` to ensure correct repository context, or run commands from within a local clone of the repository.
+1. **Required flags**: Every `gh pr-review` subcommand (`review view`, `comments reply`, `threads list`, `threads resolve`, `review --start`, `review --add-comment`, `review --submit`, etc.) requires both `--pr <number>` and `--repo <owner/repo>`. Resolve them once at the start of the workflow and reuse on every call — do not drop them in loops or per-thread reply commands.
 
 2. **Thread IDs**: Thread IDs (format `PRRT_...`) can be obtained from `review view --include-comment-node-id` or `threads list` commands.
 

--- a/github/pr-threads-address/SKILL.md
+++ b/github/pr-threads-address/SKILL.md
@@ -20,14 +20,21 @@ gh extension list | grep -q pr-review || gh extension install agynio/gh-pr-revie
 
 ### Resolve PR context
 
-Before running any `gh pr-review` subcommand, resolve the PR number and repo once and reuse them. Every `gh pr-review` subcommand requires both `--pr <number>` and `--repo <owner/repo>` — do not omit either.
+Every `gh pr-review` subcommand requires both `--pr <number>` and `--repo <owner/repo>` — do not omit either. Look the values up once at the start of the workflow and substitute the literal numbers and slugs into every later command.
+
+If the user did not pass `PR_NUMBER`, get it from the current branch:
 
 ```bash
-PR_NUMBER="${1:-$(gh pr view --json number -q .number)}"
-REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+gh pr view --json number -q .number
 ```
 
-Pass `--pr "$PR_NUMBER" --repo "$REPO"` on every subsequent `gh pr-review` call in this workflow (review view, comments reply, threads resolve, etc.).
+Get the repository slug:
+
+```bash
+gh repo view --json nameWithOwner -q .nameWithOwner
+```
+
+Then pass the resulting values directly — e.g. `--pr 42 --repo posit-dev/skills` — on every subsequent `gh pr-review` call in this workflow (review view, comments reply, threads resolve, etc.).
 
 ## Workflow
 

--- a/github/pr-threads-resolve/SKILL.md
+++ b/github/pr-threads-resolve/SKILL.md
@@ -22,7 +22,7 @@ gh extension list | grep -q pr-review || gh extension install agynio/gh-pr-revie
 
 Every `gh pr-review` subcommand requires both `--pr <number>` and `--repo <owner/repo>` — do not omit either. Look the values up once at the start of the workflow and substitute the literal numbers and slugs into every later command.
 
-If the user did not pass `PR_NUMBER`, get it from the current branch:
+Get the PR number for the current branch:
 
 ```bash
 gh pr view --json number -q .number
@@ -51,12 +51,12 @@ Use this command when you have already addressed PR review threads and want to b
 ## Example
 
 ```
-/pr-threads-resolve 42
+/pr-threads-resolve
 ```
 
 This will:
 
-- List all unresolved threads on PR #42
+- List all unresolved threads on the PR for the current branch
 - Show what each thread is about
 - Ask which threads to resolve (all or specific ones)
 - Resolve the selected threads

--- a/github/pr-threads-resolve/SKILL.md
+++ b/github/pr-threads-resolve/SKILL.md
@@ -44,65 +44,20 @@ Then pass the resulting values directly — e.g. `--pr 42 --repo posit-dev/skill
 4. Resolve the confirmed threads
 5. Report back with a summary of resolved threads
 
-## When to use
-
-Use this command when you have already addressed PR review threads and want to bulk resolve them, or when you need to clean up threads that are no longer relevant.
-
-## Example
-
-```
-/pr-threads-resolve
-```
-
-This will:
-
-- List all unresolved threads on the PR for the current branch
-- Show what each thread is about
-- Ask which threads to resolve (all or specific ones)
-- Resolve the selected threads
-- Provide a summary of resolved items
-
 ## CLI Reference
 
 ### List Review Threads
-
-Enumerate all review threads with filtering:
 
 ```bash
 gh pr-review threads list --pr <number> --repo <owner/repo>
 ```
 
-**Common filters:**
-
-- `--unresolved` — Show only unresolved threads
-- `--resolved` — Show only resolved threads
-
-### View PR Reviews and Comments
-
-Display reviews, inline comments, and replies with full context:
-
-```bash
-gh pr-review review view --pr <number> --repo <owner/repo>
-```
-
-**Common filters:**
-
-- `--reviewer <login>` — Filter by specific reviewer
-- `--states <list>` — Filter by review state (APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED)
-- `--unresolved` — Show only unresolved threads
-- `--not_outdated` — Exclude outdated threads
-- `--tail <n>` — Show only the last n replies per thread
-- `--include-comment-node-id` — Include GraphQL node IDs for replies
+Filter with `--unresolved` or `--resolved`.
 
 ### Resolve / Unresolve Threads
 
-Toggle thread resolution status:
-
 ```bash
-# Resolve a thread
 gh pr-review threads resolve --thread-id <PRRT_...> --pr <number> --repo <owner/repo>
-
-# Unresolve a thread
 gh pr-review threads unresolve --thread-id <PRRT_...> --pr <number> --repo <owner/repo>
 ```
 
@@ -115,13 +70,3 @@ gh pr-review threads list --pr 42 --unresolved --repo owner/repo | \
   jq -r '.threads[].id' | \
   xargs -I {} gh pr-review threads resolve --thread-id {} --pr 42 --repo owner/repo
 ```
-
-## Usage Notes
-
-1. **Required flags**: Every `gh pr-review` subcommand (`threads list`, `threads resolve`, `threads unresolve`, `review view`, `comments reply`, etc.) requires both `--pr <number>` and `--repo <owner/repo>`. Resolve them once at the start of the workflow and reuse on every call — do not drop them in pipelines or `xargs` loops.
-
-2. **Thread IDs**: Thread IDs (format `PRRT_...`) can be obtained from `review view --include-comment-node-id` or `threads list` commands.
-
-3. **State Filters**: When using `--states`, provide a comma-separated list: `--states APPROVED,CHANGES_REQUESTED`
-
-4. **Unresolved Focus**: Use `--unresolved --not_outdated` together to focus on actionable comments that need attention.

--- a/github/pr-threads-resolve/SKILL.md
+++ b/github/pr-threads-resolve/SKILL.md
@@ -20,14 +20,21 @@ gh extension list | grep -q pr-review || gh extension install agynio/gh-pr-revie
 
 ### Resolve PR context first
 
-Before running any `gh pr-review` subcommand, resolve the PR number and repo once and reuse them. Every `gh pr-review` subcommand requires both `--pr <number>` and `--repo <owner/repo>` — do not omit either.
+Every `gh pr-review` subcommand requires both `--pr <number>` and `--repo <owner/repo>` — do not omit either. Look the values up once at the start of the workflow and substitute the literal numbers and slugs into every later command.
+
+If the user did not pass `PR_NUMBER`, get it from the current branch:
 
 ```bash
-PR_NUMBER="${1:-$(gh pr view --json number -q .number)}"
-REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+gh pr view --json number -q .number
 ```
 
-Pass `--pr "$PR_NUMBER" --repo "$REPO"` on every subsequent `gh pr-review` call in this workflow (list, resolve, view, reply).
+Get the repository slug:
+
+```bash
+gh repo view --json nameWithOwner -q .nameWithOwner
+```
+
+Then pass the resulting values directly — e.g. `--pr 42 --repo posit-dev/skills` — on every subsequent `gh pr-review` call in this workflow (list, resolve, view, reply).
 
 ## Workflow
 
@@ -101,11 +108,12 @@ gh pr-review threads unresolve --thread-id <PRRT_...> --pr <number> --repo <owne
 
 ### Bulk Resolve Example
 
+Substitute the actual PR number and repo slug resolved in "Resolve PR context first" — the `42` / `owner/repo` below are placeholders.
+
 ```bash
-# Assumes PR_NUMBER and REPO were resolved as shown in "Resolve PR context first".
-gh pr-review threads list --pr "$PR_NUMBER" --unresolved --repo "$REPO" | \
+gh pr-review threads list --pr 42 --unresolved --repo owner/repo | \
   jq -r '.threads[].id' | \
-  xargs -I {} gh pr-review threads resolve --thread-id {} --pr "$PR_NUMBER" --repo "$REPO"
+  xargs -I {} gh pr-review threads resolve --thread-id {} --pr 42 --repo owner/repo
 ```
 
 ## Usage Notes

--- a/github/pr-threads-resolve/SKILL.md
+++ b/github/pr-threads-resolve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-threads-resolve
-description: Bulk resolve unresolved PR review threads. Useful after manually addressing threads or after using /pr-threads-address.
+description: Bulk resolve unresolved PR review threads on the current branch’s PR — typically after threads have been addressed manually or via /pr-threads-address
 compatibility: Designed for Claude Code; requires gh CLI and gh-pr-review extension
 metadata:
   author: Barret Schloerke (@schloerke)

--- a/github/pr-threads-resolve/SKILL.md
+++ b/github/pr-threads-resolve/SKILL.md
@@ -8,15 +8,17 @@ metadata:
 license: MIT
 ---
 
-# /pr-threads-resolve
+## Prerequisites
 
-**Usage:** `/pr-threads-resolve [PR_NUMBER]`
+### gh pr-review extension
 
-**Description:** Bulk resolve unresolved PR review threads. Useful after manually addressing threads or after using `/pr-threads-address`.
+Before using this command, check if the gh pr-review extension is installed:
 
-**Note:** If `PR_NUMBER` is omitted, the command will automatically detect and use the PR associated with the current branch.
+```bash
+gh extension list | grep -q pr-review || gh extension install agynio/gh-pr-review
+```
 
-## Resolve PR context first
+### Resolve PR context first
 
 Before running any `gh pr-review` subcommand, resolve the PR number and repo once and reuse them. Every `gh pr-review` subcommand requires both `--pr <number>` and `--repo <owner/repo>` — do not omit either.
 
@@ -29,12 +31,11 @@ Pass `--pr "$PR_NUMBER" --repo "$REPO"` on every subsequent `gh pr-review` call 
 
 ## Workflow
 
-1. Resolve `PR_NUMBER` and `REPO` as shown above
-2. Fetch and display all unresolved PR review threads
-3. Show thread details (file, line, comment text)
-4. Ask for confirmation or allow selective resolution
-5. Resolve the confirmed threads
-6. Report back with a summary of resolved threads
+1. Fetch and display all unresolved PR review threads
+2. Show thread details (file, line, comment text)
+3. Ask for confirmation or allow selective resolution
+4. Resolve the confirmed threads
+5. Report back with a summary of resolved threads
 
 ## When to use
 
@@ -47,19 +48,12 @@ Use this command when you have already addressed PR review threads and want to b
 ```
 
 This will:
+
 - List all unresolved threads on PR #42
 - Show what each thread is about
 - Ask which threads to resolve (all or specific ones)
 - Resolve the selected threads
 - Provide a summary of resolved items
-
-## Prerequisites
-
-Before using this command, check if the gh pr-review extension is installed:
-
-```bash
-gh extension list | grep -q pr-review || gh extension install agynio/gh-pr-review
-```
 
 ## CLI Reference
 

--- a/github/pr-threads-resolve/SKILL.md
+++ b/github/pr-threads-resolve/SKILL.md
@@ -16,13 +16,25 @@ license: MIT
 
 **Note:** If `PR_NUMBER` is omitted, the command will automatically detect and use the PR associated with the current branch.
 
+## Resolve PR context first
+
+Before running any `gh pr-review` subcommand, resolve the PR number and repo once and reuse them. Every `gh pr-review` subcommand requires both `--pr <number>` and `--repo <owner/repo>` — do not omit either.
+
+```bash
+PR_NUMBER="${1:-$(gh pr view --json number -q .number)}"
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+```
+
+Pass `--pr "$PR_NUMBER" --repo "$REPO"` on every subsequent `gh pr-review` call in this workflow (list, resolve, view, reply).
+
 ## Workflow
 
-1. Fetch and display all unresolved PR review threads
-2. Show thread details (file, line, comment text)
-3. Ask for confirmation or allow selective resolution
-4. Resolve the confirmed threads
-5. Report back with a summary of resolved threads
+1. Resolve `PR_NUMBER` and `REPO` as shown above
+2. Fetch and display all unresolved PR review threads
+3. Show thread details (file, line, comment text)
+4. Ask for confirmation or allow selective resolution
+5. Resolve the confirmed threads
+6. Report back with a summary of resolved threads
 
 ## When to use
 
@@ -96,15 +108,15 @@ gh pr-review threads unresolve --thread-id <PRRT_...> --pr <number> --repo <owne
 ### Bulk Resolve Example
 
 ```bash
-# Get all unresolved thread IDs and resolve them
-gh pr-review threads list --pr 42 --unresolved --repo owner/repo | \
+# Assumes PR_NUMBER and REPO were resolved as shown in "Resolve PR context first".
+gh pr-review threads list --pr "$PR_NUMBER" --unresolved --repo "$REPO" | \
   jq -r '.threads[].id' | \
-  xargs -I {} gh pr-review threads resolve --thread-id {} --pr 42 --repo owner/repo
+  xargs -I {} gh pr-review threads resolve --thread-id {} --pr "$PR_NUMBER" --repo "$REPO"
 ```
 
 ## Usage Notes
 
-1. **Repository Context**: Always include `--repo owner/repo` to ensure correct repository context, or run commands from within a local clone of the repository.
+1. **Required flags**: Every `gh pr-review` subcommand (`threads list`, `threads resolve`, `threads unresolve`, `review view`, `comments reply`, etc.) requires both `--pr <number>` and `--repo <owner/repo>`. Resolve them once at the start of the workflow and reuse on every call — do not drop them in pipelines or `xargs` loops.
 
 2. **Thread IDs**: Thread IDs (format `PRRT_...`) can be obtained from `review view --include-comment-node-id` or `threads list` commands.
 


### PR DESCRIPTION
## Summary

- Both `pr-threads-address` and `pr-threads-resolve` previously promised auto-detection of the PR number when omitted, but never told Claude *how* to do it, and `--pr` / `--repo` were only shown in examples (not flagged as required). This led to bulk loops and per-thread replies dropping `--pr`.
- Add a "Resolve PR context first" section to both skills that captures `PR_NUMBER` and `REPO` once via `gh pr view` / `gh repo view`, and instructs reusing them on every subsequent `gh pr-review` call.
- Promote the soft "Repository Context" usage note to a hard "Required flags" rule that enumerates every affected subcommand.
- Rewrite the bulk-resolve example in `pr-threads-resolve` to use `"$PR_NUMBER"` / `"$REPO"` instead of hardcoded `42` / `owner/repo`.

## Test plan

- [ ] Run `/pr-threads-resolve` with no PR number on a branch with an open PR; confirm Claude resolves the PR number first and passes `--pr` on every `gh pr-review` call.
- [ ] Run `/pr-threads-address` similarly and confirm `--pr` / `--repo` are passed on `comments reply` and `threads resolve`.
- [x] Spot-check `./count-skill-tokens.py github/pr-threads-resolve` and `github/pr-threads-address` are still under limits.