### PR TITLE
Add render-plan skill: markdown plans to Posit-themed HTML

### DIFF
--- a/posit-dev/render-plan/SKILL.md
+++ b/posit-dev/render-plan/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: render-plan
+description: Use when you have a finalized markdown plan or spec file and need to share it as a polished, Posit-themed HTML deliverable. Handles plans, specs, design docs, and similar prose-heavy markdown that needs to leave Claude looking like a finished document.
+---
+
+# render-plan
+
+Render a markdown plan or spec to a self-contained, Posit-themed HTML document. Applies the Posit style guide to the source markdown first, then renders with Quarto using the canonical Posit `_brand.yml`.
+
+## When to use this skill
+
+- A plan, spec, design doc, or similar prose `.md` is finalized and needs to be shared as a polished document.
+- The recipient should not need Quarto, a brand file, or any toolchain to read it — output is a single self-contained `.html`.
+- The source markdown should also be cleaned up against the Posit style guide as part of the operation.
+
+This skill is **not** for: authoring new content (write the `.md` first), generic markdown-to-HTML rendering (use Quarto directly), or producing PDF/DOCX (HTML only).
+
+## Prerequisites
+
+Quarto must be installed and on `PATH`. Verify with `quarto --version`. If missing:
+
+- macOS: `brew install quarto`
+- Linux: <https://quarto.org/docs/get-started/>
+- Windows: <https://quarto.org/docs/get-started/>
+
+If Quarto is missing, **stop the pipeline before invoking doc-reviewer** — otherwise the source file gets edited but no HTML is produced.
+
+## Arguments
+
+- `<path-to-plan.md>` — required. Path to the source markdown file.
+- `--no-open` — optional. Do not auto-open the rendered HTML in a browser.
+
+## Workflow
+
+Execute these steps in order. Stop on the first failure.
+
+1. **Validate input.** Confirm the path exists and ends in `.md`. If not, report the mismatch and stop. Source is not modified.
+
+2. **Check Quarto.** Run `command -v quarto`. If it returns nothing, print the install instructions for the user's OS (see Prerequisites) and stop. Do this **before** step 3 so a missing install never leaves the source edited with no HTML to show for it.
+
+3. **Apply the Posit style guide.** Invoke the `doc-reviewer` skill against the source file:
+
+   ```
+   Skill("doc-reviewer")
+   ```
+
+   doc-reviewer writes its edits to the source `.md` in place. The user ends up with a cleaned-up plan alongside the rendered HTML — this is intentional.
+
+4. **Render.** Run the wrapper script with the (now edited) input file:
+
+   ```bash
+   bash "<skill-dir>/scripts/render.sh" "<path-to-plan.md>" [--no-open]
+   ```
+
+   The script stages a temp workspace with the input, the vendored `_brand.yml`, and a generated `_quarto.yml` (which enables `embed-resources: true`). It runs `quarto render`, moves the self-contained HTML next to the original `.md` (overwriting any existing file of the same name), and opens it in the browser unless `--no-open` was passed.
+
+5. **Report.** Print the absolute output path returned by the script.
+
+## Error handling
+
+| Failure | Behavior |
+|---------|----------|
+| Input file missing or wrong extension | Stop with an error. Source is not modified. |
+| Quarto missing | Print OS-specific install instructions and stop. Source is not modified. |
+| `doc-reviewer` fails | Stop before render. Source file may be partially modified; report this. |
+| `quarto render` fails | Stop and print Quarto's stderr. The source has already been edited by `doc-reviewer`; mention this so the user is not surprised by dirty git status. |
+| Browser open fails | Warn but do not fail. Output path is already printed. |
+
+## Skill-to-skill chain
+
+Step 3 invokes the `doc-reviewer` skill via Claude's `Skill` tool. This is intentional and documented here so future maintainers understand the dependency: `render-plan` is a thin orchestration over the existing `doc-reviewer` skill and a Quarto render. If `doc-reviewer` changes its contract (e.g., starts requiring an explicit file path argument), update step 3.
+
+## Keywords
+
+render, plan, spec, html, Posit, theming, brand.yml, quarto, doc-reviewer, design doc, deliverable, embed-resources, self-contained, style guide

--- a/posit-dev/render-plan/scripts/render.sh
+++ b/posit-dev/render-plan/scripts/render.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# render.sh — Render a markdown plan to Posit-themed HTML using Quarto.
+#
+# Usage:
+#   render.sh <path-to-plan.md> [--no-open]
+#
+# Arguments:
+#   <path-to-plan.md>  Required. Path to the source markdown file.
+#   --no-open          Optional. Do not auto-open the rendered HTML in a browser.
+#
+# Behavior:
+#   1. Validates that the input file exists and has a .md extension.
+#   2. Stages a temp workspace with the input, the vendored _brand.yml, and
+#      a generated _quarto.yml that enables brand theming and embed-resources.
+#   3. Runs `quarto render` to produce a self-contained HTML file.
+#   4. Moves the HTML next to the original input (overwriting any existing file).
+#   5. Opens the HTML in the default browser unless --no-open was passed.
+#   6. Prints the absolute output path on stdout.
+#
+# Notes:
+#   This script does NOT check for Quarto or invoke doc-reviewer.
+#   Both responsibilities sit upstream in SKILL.md, which Claude executes
+#   before calling this script.
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: render.sh <path-to-plan.md> [--no-open]
+
+Render a markdown plan to Posit-themed HTML using Quarto.
+
+Arguments:
+  <path-to-plan.md>  Required. Path to the source markdown file.
+  --no-open          Optional. Do not auto-open the rendered HTML in a browser.
+USAGE
+}
+
+INPUT=""
+OPEN=1
+for arg in "$@"; do
+  case "$arg" in
+    --no-open) OPEN=0 ;;
+    --help|-h) usage; exit 0 ;;
+    -*) echo "Unknown flag: $arg" >&2; usage >&2; exit 2 ;;
+    *)
+      if [ -z "$INPUT" ]; then
+        INPUT="$arg"
+      else
+        echo "Unexpected extra argument: $arg" >&2
+        usage >&2
+        exit 2
+      fi
+      ;;
+  esac
+done
+
+if [ -z "$INPUT" ]; then
+  echo "Error: missing required <path-to-plan.md> argument." >&2
+  usage >&2
+  exit 2
+fi
+
+if [ ! -f "$INPUT" ]; then
+  echo "Error: input file not found: $INPUT" >&2
+  exit 1
+fi
+
+case "$INPUT" in
+  *.md) ;;
+  *)
+    echo "Error: input must have .md extension: $INPUT" >&2
+    exit 1
+    ;;
+esac
+
+INPUT_ABS="$(cd "$(dirname "$INPUT")" && pwd)/$(basename "$INPUT")"
+INPUT_DIR="$(dirname "$INPUT_ABS")"
+INPUT_BASE="$(basename "$INPUT_ABS" .md)"
+OUTPUT_ABS="$INPUT_DIR/$INPUT_BASE.html"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BRAND_SRC="$SCRIPT_DIR/../templates/_brand.yml"
+
+if [ ! -f "$BRAND_SRC" ]; then
+  echo "Error: vendored _brand.yml not found at $BRAND_SRC" >&2
+  exit 1
+fi
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+cp "$INPUT_ABS" "$STAGE/$INPUT_BASE.md"
+cp "$BRAND_SRC" "$STAGE/_brand.yml"
+
+cat > "$STAGE/_quarto.yml" <<'QUARTO_YML'
+project:
+  type: default
+format:
+  html:
+    embed-resources: true
+QUARTO_YML
+
+if ! quarto render "$STAGE/$INPUT_BASE.md" --to html >/tmp/render-plan-quarto.log 2>&1; then
+  echo "Error: quarto render failed. See /tmp/render-plan-quarto.log for details." >&2
+  echo "Note: the source markdown may already have been edited by doc-reviewer." >&2
+  exit 1
+fi
+
+mv -f "$STAGE/$INPUT_BASE.html" "$OUTPUT_ABS"
+
+if [ "$OPEN" -eq 1 ]; then
+  case "$(uname -s)" in
+    Darwin) open "$OUTPUT_ABS" >/dev/null 2>&1 || echo "Warning: failed to open browser." >&2 ;;
+    Linux)  xdg-open "$OUTPUT_ABS" >/dev/null 2>&1 || echo "Warning: failed to open browser." >&2 ;;
+    MINGW*|MSYS*|CYGWIN*) start "$OUTPUT_ABS" >/dev/null 2>&1 || echo "Warning: failed to open browser." >&2 ;;
+    *) echo "Warning: unknown OS, skipping browser open." >&2 ;;
+  esac
+fi
+
+echo "$OUTPUT_ABS"

--- a/posit-dev/render-plan/templates/_brand.yml
+++ b/posit-dev/render-plan/templates/_brand.yml
@@ -1,0 +1,56 @@
+meta:
+  name:
+    full: Posit Software, PBC
+    short: Posit
+  link:
+    home: https://posit.co
+    guide: https://positpbc.atlassian.net/wiki/x/AQAgBQ
+    mastodon: https://fosstodon.org/@Posit
+    linkedin: https://www.linkedin.com/company/posit-software/
+    twitter: https://twitter.com/posit_pbc
+
+color:
+  palette:
+    blue: "#447099"
+    orange: "#EE6331"
+    gray: "#404041"
+    white: "#FFFFFF"
+    teal: "#419599"
+    green: "#72994E"
+    burgundy: "#9A4665"
+    accent: orange
+  foreground: "#151515"
+  background: "#FFFFFF"
+  primary: "#447099"
+  secondary: "#707073"
+  tertiary: "#C2C2C4"
+  success: "#72994E"
+  info: "#419599"
+  warning: "#EE6331"
+  danger: "#9A4665"
+  light: "#FFFFFF"
+  dark: "#404041"
+
+typography:
+  fonts:
+    - source: google
+      family: Open Sans
+    - source: google
+      family: Fira Code
+    - source: google
+      family: Roboto Slab
+      weight: 600
+      style: normal
+      display: block
+
+  base:
+    family: "Open Sans"
+    line-height: 1.25
+    size: 1rem
+  headings:
+    family: "Roboto Slab"
+    color: primary
+    weight: 600
+  monospace:
+    family: "Fira Code"
+    size: 0.9em


### PR DESCRIPTION
## Summary

- Adds a new `posit-dev/render-plan` skill that takes a markdown plan or spec file and produces a Posit-themed `.html` via Quarto.
- Applies the Posit style guide to the source `.md` automatically by chaining the existing `doc-reviewer` skill before rendering.
- Vendors `posit-dev/brand-yml/examples/brand-posit.yml` (with the `logo:` block removed since the placeholder logo filenames don't ship with brand-yml) so the skill works offline.

## Why

Plan and spec documents inside Claude Code sessions often need to leave Claude as a polished deliverable. Rendering through `quarto` + `_brand.yml` gives the right look out of the box; combining it with `doc-reviewer` produces a one-shot "make this plan presentable" command. The output is a single self-contained `.html` (via Quarto's `embed-resources`) — no sidecar `_files/` dir, no toolchain required on the recipient's side.

## How it works

1. Claude validates the input file and checks `quarto --version`. If Quarto is missing, the skill prints OS-specific install instructions and stops **before** touching the source.
2. Claude invokes `Skill("doc-reviewer")` against the source `.md`; edits are written in place.
3. Claude runs `scripts/render.sh`, which stages a temp workspace with the vendored `_brand.yml` and a generated `_quarto.yml` (with `embed-resources: true`), runs `quarto render`, moves the HTML next to the source, and opens it in the browser unless `--no-open` was passed.

## Test plan

- [x] Run `/render-plan path/to/plan.md` on a sample plan — HTML opens with Posit theming.
- [x] Run with `--no-open` — HTML is created but no browser opens.
- [x] Run with a non-existent path — non-zero exit, clear error.
- [x] Run on a system without Quarto — install instructions print, source is not modified.
- [x] Run on a style-guide-violating `.md` — source is edited in place by `doc-reviewer`.