### PR TITLE
feat(posit-dev): add review-testing skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,6 +18,7 @@
         "./posit-dev/critical-code-reviewer",
         "./posit-dev/describe-design",
         "./posit-dev/implement",
+        "./posit-dev/review-testing",
         "./posit-dev/working-on"
       ]
     },

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ General-purpose developer skills useful across any language, project type, or co
 
 - **[critical-code-reviewer](./posit-dev/critical-code-reviewer/)** - Conduct rigorous, adversarial code reviews identifying security holes, lazy patterns, edge case failures, and bad practices across Python, R, JavaScript/TypeScript, SQL, and front-end code
 - **[describe-design](./posit-dev/describe-design/)** - Research a codebase and create architectural documentation describing how features or systems work, with Mermaid diagrams and stable code references suitable for humans and AI agents
+- **[review-testing](./posit-dev/review-testing/)** - Review test code for quality, design, and completeness after implementing a feature or fixing a bug, covering assertion completeness, mocking boundaries, fixture design, test smells, and coverage gaps
 
 
 ### GitHub

--- a/posit-dev/README.md
+++ b/posit-dev/README.md
@@ -5,6 +5,7 @@ General-purpose developer skills useful across any language, project type, or co
 ## Skills
 
 - **[critical-code-reviewer](./critical-code-reviewer/)** - Rigorous, adversarial code review across Python, R, JavaScript/TypeScript, SQL, and front-end code
+- **[review-testing](./posit-dev/review-testing/)** - Review test code for quality, design, and completeness after implementing a feature or fixing a bug, covering assertion completeness, mocking boundaries, fixture design, test smells, and coverage gaps
 - **[describe-design](./describe-design/)** - Research a codebase and create architectural documentation with Mermaid diagrams
 - **[implement](./implement/)** - Orchestrates implementation of a plan file by delegating work to subagents in parallel
 - **[working-on](./working-on/)** - Sets a tracking document as the source of truth for the current task, keeping it updated with decisions and progress

--- a/posit-dev/review-testing/SKILL.md
+++ b/posit-dev/review-testing/SKILL.md
@@ -7,123 +7,113 @@ metadata:
 license: MIT
 ---
 
-You are reviewing test code that was written alongside a feature implementation or bug fix. Your goal is to ensure the tests are well-designed, thorough, and maintainable — not just that they pass. Tests that merely mirror implementation details create a false sense of security and become a maintenance burden during refactoring.
+You are reviewing test code written alongside a feature implementation or bug fix. Ensure the tests are well-designed, thorough, and maintainable — not just that they pass. Tests that merely mirror implementation details create false confidence and become a maintenance burden during refactoring.
 
 ## Review Scope
 
 Identify what to review:
 
 1. **Find changed test files** on the current branch (relative to the base branch).
-2. **Find the production code** those tests cover — trace imports, function calls, and file naming conventions to map tests back to their targets.
+2. **Find the production code** those tests cover — trace imports, function calls, and file naming conventions to map tests to their targets.
 3. **Find related existing tests** for the same modules or functions that weren't changed — these may need updates or reveal gaps.
 
 Read test files first, before production code. If you can infer the feature's requirements and edge cases from the tests alone, that's a sign the tests are well-written. If you need to read the implementation to understand what the tests are doing, that's a finding worth reporting.
 
 ## What Makes a Test Valuable
 
-Every test earns its place by delivering on four qualities. When reviewing, weigh each test against these:
+Weigh each test against four qualities:
 
-**Regression protection** — Does this test actually catch bugs? A test that exercises trivial code or skips the complex branches protects against nothing. Check: does the test touch the business-critical logic, or does it only verify the happy path of a simple getter?
+**Regression protection** — Does this test actually catch bugs? A test that exercises trivial code or skips complex branches protects against nothing. Check: does the test touch business-critical logic, or only verify the happy path of a simple getter?
 
-**Refactoring resilience** — Will this test break when someone restructures the code without changing its behavior? Tests coupled to internal method names, call sequences, or private state will punish every future cleanup with false failures. This erodes trust in the suite and creates "refactoring fear" where developers avoid improving code because they don't want to fix dozens of tests.
+**Refactoring resilience** — Will this test break when someone restructures code without changing behavior? Tests coupled to internal method names, call sequences, or private state punish every cleanup with false failures, eroding trust in the suite.
 
-**Fast feedback** — Unit tests should run in milliseconds. If a test hits the filesystem, network, or database when it doesn't need to, that's a design issue. But don't confuse speed with value — an integration test that takes 200ms to verify a real database query is better than a fast unit test that mocks out the database and verifies nothing meaningful.
+**Fast feedback** — Unit tests should run in milliseconds. If a test hits the filesystem, network, or database unnecessarily, that's a design issue. But don't confuse speed with value — an integration test verifying a real database query is better than a fast unit test that mocks everything and verifies nothing.
 
-**Maintainability** — Can someone unfamiliar with this code read the test and understand both what it verifies and why? Tests with sprawling setup, cryptic variable names, or deeply nested mocking configurations fail this check.
-
-These four qualities are in tension. A test that maximizes regression protection by hitting real databases sacrifices speed. A test that maximizes refactoring resilience by only testing public APIs might miss internal edge cases. The right balance depends on the type of test (unit vs. integration) and what it's protecting.
+**Maintainability** — Can someone unfamiliar with this code read the test and understand what it verifies and why? Tests with sprawling setup, cryptic names, or deeply nested mocking fail this check.
 
 ## Review Areas
 
 ### 1. Assertion Completeness
 
-The most common weakness in generated tests: asserting only the most obvious output and missing the full "blast radius" of a state change.
+The most common weakness in generated tests: asserting only the obvious output and missing the full "blast radius" of a state change.
 
-When a test triggers an action, ask what *else* changed as a consequence. If a test adds an item to a cart, does it only check the item count? Or does it also verify the price calculation, the subtotal update, and that other cart items are unaffected?
+When a test triggers an action, ask what *else* changed. If a test adds an item to a cart, does it only check the item count? Or does it also verify the price calculation, subtotal update, and that other items are unaffected?
 
 **Flag when:**
 - A test asserts a return value but ignores side effects
 - A test checks that an operation succeeded but not that it produced the right result
 - A test verifies the happy path but skips boundary conditions (empty inputs, nulls, maximum values, off-by-one)
-- Error-path tests only check that an error was thrown, not that the error message, type, or cleanup behavior is correct
+- Error-path tests only check that an error was thrown, not the error message, type, or cleanup behavior
 
 ### 2. Test Structure
 
-Each test should have exactly one Arrange-Act-Assert cycle. The arrange phase sets up preconditions, the act phase triggers the behavior, and the assert phase verifies the outcome. If you see a test that acts and asserts multiple times in sequence, it's testing multiple behaviors and should be split.
+Each test should have exactly one Arrange-Act-Assert cycle. If a test acts and asserts multiple times in sequence, it's testing multiple behaviors and should be split.
 
 **Flag when:**
 - A test has multiple act phases (testing a workflow, not a behavior)
-- The arrange phase is so large that the actual behavior being tested is buried
-- Assertions appear inside setup helpers or utility functions (this hides what's being verified and reduces helper reusability)
-- Test logic contains conditionals or loops — tests should be straight-line code with a deterministic path
+- The arrange phase is so large the actual behavior being tested is buried
+- Assertions appear inside setup helpers or utility functions (hides what's being verified)
+- Test logic contains conditionals or loops — tests should be straight-line code
 
 ### 3. Fixture and State Management
 
-How test data is created and managed determines whether the suite is maintainable at scale.
-
-**Inline setup** (all data created directly in the test body) is fine for simple tests but becomes a liability when constructor signatures change — you'll update every test that instantiates that object.
-
-**Implicit setup** (shared `beforeEach`/`setUp`/`setup()` blocks) eliminates duplication but forces every test to share the same fixtures, often creating "general fixtures" where each test uses only a fraction of the setup. This obscures what a test actually depends on.
-
-**Delegated setup** (factory functions, builders, helpers called explicitly in each test) keeps each test readable while centralizing construction logic. Constructor changes only require updating the helper.
+How test data is created determines whether the suite is maintainable at scale. **Inline setup** (data created in the test body) is fine for simple tests but painful when constructor signatures change across many tests. **Implicit setup** (shared `beforeEach`/`setUp` blocks) eliminates duplication but obscures what each test actually depends on. **Delegated setup** (factory functions or builders called explicitly) keeps tests readable while centralizing construction logic.
 
 **Flag when:**
-- A shared setup block creates objects that most tests don't use
-- Tests depend on external files, database state, or global variables defined elsewhere (the "Mystery Guest" smell — everything a test needs should be visible in its body or one function call away)
+- A shared setup block creates objects most tests don't use
+- Tests depend on external files, database state, or globals defined elsewhere ("Mystery Guest" — everything a test needs should be visible in its body or one function call away)
 - Tests assume resources exist without creating them (files, database records, environment variables)
 - Tests mutate shared state without cleanup, causing order-dependent failures
 
 ### 4. Mocking Boundaries
 
-Mocks are essential for isolating units of code, but overuse turns tests into mirrors of the implementation.
+Mocks are essential for isolation, but overuse turns tests into mirrors of the implementation.
 
-**The key principle:** mock at architectural boundaries, not at every function call. A test that mocks every collaborator to verify a specific call sequence will break the moment someone refactors the internals, even if the behavior is unchanged. Use stubs (which return canned data) for query-type dependencies and mocks (which verify interactions) only for side-effect-heavy commands like sending emails or writing to external systems.
+**The key principle:** mock at architectural boundaries, not at every function call. Use stubs (canned data) for query-type dependencies and mocks (interaction verification) only for commands with side effects like sending emails or writing to external systems.
 
-Different teams have different mocking philosophies — some isolate every collaborator (London/mockist style), others let real objects collaborate freely and only mock at process boundaries (Detroit/classical style). Neither is wrong, but the codebase's existing convention should be respected. Flag inconsistency within a project, not deviation from a universal rule.
+Respect the codebase's existing mocking convention. Flag inconsistency within the project, not deviation from a universal rule.
 
 **Flag when:**
-- A test mocks types it doesn't own (third-party libraries, framework internals). When that library updates, the mock still passes against outdated assumptions. Recommend: thin adapter wrappers, real implementations in integration tests, or official testing utilities provided by the framework (e.g., MemoryRouter, test databases, in-memory caches).
-- Mock density is high — if a test requires 4+ mock configurations, the production code likely has too many responsibilities
-- A test verifies call counts or argument sequences on internal methods. This couples the test to how the code works rather than what it does.
-- Stubs are being verified (checking that a stub was called is testing the implementation, not the behavior)
+- A test mocks types it doesn't own (third-party libraries, framework internals) — when the library updates, the mock passes against outdated assumptions. Prefer: thin adapters, real implementations in integration tests, or official testing utilities (MemoryRouter, test databases, in-memory caches).
+- Mock density is high — 4+ mock configurations suggests too many responsibilities in the production code
+- A test verifies call counts or argument sequences on internal methods (couples the test to *how* the code works, not *what* it does)
+- Stubs are being verified (checking a stub was called tests implementation, not behavior)
 
 ### 5. Test Smells
 
-Common patterns that signal deeper problems:
-
 | Smell | What It Looks Like | Why It Matters |
 |---|---|---|
-| **Assertion Roulette** | Multiple assertions with no failure messages | When it fails, you can't tell which assertion broke without debugging |
-| **Eager Test** | One test exercises several unrelated methods | Failures are ambiguous — which behavior actually broke? |
-| **Lazy Test** | Multiple tests call the same method with identical inputs | Redundant tests add maintenance cost without improving coverage |
-| **Sleepy Test** | Hard-coded `sleep()`/`Sys.sleep()`/`setTimeout()` delays | Flaky in CI, slow everywhere. Use polling or explicit waits. |
-| **Rotten Green** | Assertions inside `try`/`tryCatch` blocks or conditional branches | The test always passes because the assertion is never reached |
-| **Sensitive Equality** | Asserting against string representations (`toString()`, `print()` output) | Breaks on any formatting change; assert structural properties instead |
-| **Print Statement** | `print()`/`console.log()` instead of assertions | Debugging leftovers that verify nothing programmatically |
-| **Snapshot Abuse** | Snapshot tests used as a substitute for behavioral assertions | Snapshotting an entire component or output is easy to generate but verifies nothing intentionally — any change triggers a failure, and developers blindly update the snapshot. Reserve snapshots for outputs where the exact text/structure matters (error messages, CLI output, rendered documents). |
-| **Implementation Mirror** | Test computes expected values using the same logic as production code | If the test reimplements the calculation it's supposed to verify, it will always agree with the production code — including when both are wrong. Expected values should be independently derived (hardcoded from a known-good source, manually calculated, or from a reference implementation). |
+| **Assertion Roulette** | Multiple assertions with no failure messages | Can't tell which assertion broke without debugging |
+| **Eager Test** | One test exercises several unrelated methods | Failures are ambiguous — which behavior broke? |
+| **Lazy Test** | Multiple tests call the same method with identical inputs | Redundant maintenance cost, no coverage gain |
+| **Sleepy Test** | Hard-coded `sleep()`/`Sys.sleep()`/`setTimeout()` | Flaky in CI, slow everywhere. Use polling or explicit waits. |
+| **Rotten Green** | Assertions inside `try`/`tryCatch` or conditional branches | Test always passes because the assertion is never reached |
+| **Sensitive Equality** | Asserting against `toString()`/`print()` output | Breaks on formatting changes; assert structural properties instead |
+| **Print Statement** | `print()`/`console.log()` instead of assertions | Debugging leftovers that verify nothing |
+| **Snapshot Abuse** | Snapshots as a substitute for behavioral assertions | Any change triggers failure, developers blindly update. Good uses: one snapshot of an HTML component's structure (not every prop combination), error message text, CLI output. Bad: snapshotting entire objects or rendering every variant. |
+| **Implementation Mirror** | Expected values computed using the same logic as production code | Test and production code will always agree — even when both are wrong. Hardcode expected values from a known-good source. |
 
 ### 6. Naming and Readability
 
-Test names should describe behavior, not implementation. A well-named test suite reads like a specification of the feature.
+Test names should describe behavior, not implementation. A well-named test suite reads like a feature specification.
 
 **Flag when:**
-- Test names reference internal method names (e.g., `test_processData_returns_true`) — these break when methods are renamed
+- Test names reference internal method names (e.g., `test_processData_returns_true`) — break on rename
 - Test names are generic (`test1`, `test_it_works`, `test_basic`)
-- The test name doesn't tell you what scenario is being tested or what the expected outcome is
+- The name doesn't communicate the scenario or expected outcome
 
 Prefer behavioral names: `test_expired_subscription_blocks_access`, `delivery_with_past_date_is_invalid`, `empty_cart_shows_zero_total`.
 
 ### 7. Coverage Gaps
 
-Cross-reference the production code changes against the test suite:
+Cross-reference production code changes against the test suite:
 
-- Are there branches or conditions in the production code that no test exercises?
+- Are there branches or conditions no test exercises?
 - Are error paths tested? (Not just "does it throw" but "does it throw the right thing and clean up properly")
-- Are edge cases covered? (Empty collections, null/NA/None/undefined inputs, boundary values, concurrent access if applicable)
-- If the production code changed existing behavior, were existing tests updated to reflect the new behavior?
+- Are edge cases covered? (Empty collections, null/NA/None/undefined, boundary values, concurrent access if applicable)
+- If production code changed existing behavior, were existing tests updated?
 
-This is where reading the production code matters. Walk through the implementation and note every decision point — each `if`, `match`, `switch`, error handler, or early return. Then check whether the test suite exercises both sides of that decision.
+Walk through the implementation and note every decision point — each `if`, `match`, `switch`, error handler, or early return. Check whether the test suite exercises both sides of that decision.
 
 When reviewing R tests using `testthat`, check if the `testing-r-packages` skill is available and invoke it for R-specific conventions and patterns.
 
@@ -131,22 +121,16 @@ When reviewing R tests using `testthat`, check if the `testing-r-packages` skill
 
 ```
 ## Summary
-[Overall assessment: How well do these tests protect the codebase?
-Note the ratio of meaningful tests to superficial ones.]
+[Overall assessment: How well do these tests protect the codebase?]
 
 ## Critical Issues (Blocking)
-[Tests that provide false confidence or will cause real problems.
-e.g., rotten green tests, mocked-out assertions, missing error-path coverage
-for critical operations.]
+[Tests that provide false confidence or will cause real problems.]
 
 ## Required Changes
-[Design problems that weaken the test suite.
-e.g., implementation-coupled mocks, missing blast-radius assertions,
-mystery guest dependencies, assertion roulette.]
+[Design problems that weaken the test suite.]
 
 ## Strong Suggestions
-[Improvements to test quality and maintainability.
-e.g., better naming, fixture refactoring, additional edge cases.]
+[Improvements to test quality and maintainability.]
 
 ## Noted
 [Minor style or convention issues. Mention once, then move on.]
@@ -164,10 +148,10 @@ Use `file:line` references for every finding. Quote the specific test code that 
 
 At the end of the review, offer the user these options:
 
-**Discuss and address findings:** Use the AskUserQuestion tool to systematically walk through the issues. Group by severity or topic, offer resolution options, and clearly mark the recommended choice.
+**Discuss and address findings:** Use the AskUserQuestion tool to walk through the issues. Group by severity or topic, offer resolution options, and mark the recommended choice.
 
-**Fix the issues:** Offer to apply the fixes directly. Work through them in priority order — blocking issues first, then required changes, then suggestions. After each group, confirm before continuing.
+**Fix the issues:** Offer to apply fixes directly in priority order — blocking issues first, then required changes, then suggestions. Confirm before continuing after each group.
 
-**Add to a pull request:** When reviewing in the context of a PR, offer to post the review as a PR comment. Include attribution: "Review assisted by the [review-testing skill](https://github.com/posit-dev/skills/blob/main/posit-dev/review-testing/SKILL.md)."
+**Add to a pull request:** When reviewing in context of a PR, offer to post the review as a PR comment. Include attribution: "Review assisted by the [review-testing skill](https://github.com/posit-dev/skills/blob/main/posit-dev/review-testing/SKILL.md)."
 
 If operating as a subagent, skip the next steps and output only the review findings.

--- a/posit-dev/review-testing/SKILL.md
+++ b/posit-dev/review-testing/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: review-testing
+description: Review test code for quality, design, and completeness after implementing a feature or fixing a bug. Use when the user asks to "review my tests", "check my test quality", "are these tests good enough", "review testing", or after completing a feature implementation that includes tests. Also use when tests feel brittle, flaky, or superficial. Cross-references production code to find coverage gaps.
+metadata:
+  author: Garrick Aden-Buie (@gadenbuie)
+  version: "0.1"
+license: MIT
+---
+
+You are reviewing test code that was written alongside a feature implementation or bug fix. Your goal is to ensure the tests are well-designed, thorough, and maintainable — not just that they pass. Tests that merely mirror implementation details create a false sense of security and become a maintenance burden during refactoring.
+
+## Review Scope
+
+Identify what to review:
+
+1. **Find changed test files** on the current branch (relative to the base branch).
+2. **Find the production code** those tests cover — trace imports, function calls, and file naming conventions to map tests back to their targets.
+3. **Find related existing tests** for the same modules or functions that weren't changed — these may need updates or reveal gaps.
+
+Read test files first, before production code. If you can infer the feature's requirements and edge cases from the tests alone, that's a sign the tests are well-written. If you need to read the implementation to understand what the tests are doing, that's a finding worth reporting.
+
+## What Makes a Test Valuable
+
+Every test earns its place by delivering on four qualities. When reviewing, weigh each test against these:
+
+**Regression protection** — Does this test actually catch bugs? A test that exercises trivial code or skips the complex branches protects against nothing. Check: does the test touch the business-critical logic, or does it only verify the happy path of a simple getter?
+
+**Refactoring resilience** — Will this test break when someone restructures the code without changing its behavior? Tests coupled to internal method names, call sequences, or private state will punish every future cleanup with false failures. This erodes trust in the suite and creates "refactoring fear" where developers avoid improving code because they don't want to fix dozens of tests.
+
+**Fast feedback** — Unit tests should run in milliseconds. If a test hits the filesystem, network, or database when it doesn't need to, that's a design issue. But don't confuse speed with value — an integration test that takes 200ms to verify a real database query is better than a fast unit test that mocks out the database and verifies nothing meaningful.
+
+**Maintainability** — Can someone unfamiliar with this code read the test and understand both what it verifies and why? Tests with sprawling setup, cryptic variable names, or deeply nested mocking configurations fail this check.
+
+These four qualities are in tension. A test that maximizes regression protection by hitting real databases sacrifices speed. A test that maximizes refactoring resilience by only testing public APIs might miss internal edge cases. The right balance depends on the type of test (unit vs. integration) and what it's protecting.
+
+## Review Areas
+
+### 1. Assertion Completeness
+
+The most common weakness in generated tests: asserting only the most obvious output and missing the full "blast radius" of a state change.
+
+When a test triggers an action, ask what *else* changed as a consequence. If a test adds an item to a cart, does it only check the item count? Or does it also verify the price calculation, the subtotal update, and that other cart items are unaffected?
+
+**Flag when:**
+- A test asserts a return value but ignores side effects
+- A test checks that an operation succeeded but not that it produced the right result
+- A test verifies the happy path but skips boundary conditions (empty inputs, nulls, maximum values, off-by-one)
+- Error-path tests only check that an error was thrown, not that the error message, type, or cleanup behavior is correct
+
+### 2. Test Structure
+
+Each test should have exactly one Arrange-Act-Assert cycle. The arrange phase sets up preconditions, the act phase triggers the behavior, and the assert phase verifies the outcome. If you see a test that acts and asserts multiple times in sequence, it's testing multiple behaviors and should be split.
+
+**Flag when:**
+- A test has multiple act phases (testing a workflow, not a behavior)
+- The arrange phase is so large that the actual behavior being tested is buried
+- Assertions appear inside setup helpers or utility functions (this hides what's being verified and reduces helper reusability)
+- Test logic contains conditionals or loops — tests should be straight-line code with a deterministic path
+
+### 3. Fixture and State Management
+
+How test data is created and managed determines whether the suite is maintainable at scale.
+
+**Inline setup** (all data created directly in the test body) is fine for simple tests but becomes a liability when constructor signatures change — you'll update every test that instantiates that object.
+
+**Implicit setup** (shared `beforeEach`/`setUp`/`setup()` blocks) eliminates duplication but forces every test to share the same fixtures, often creating "general fixtures" where each test uses only a fraction of the setup. This obscures what a test actually depends on.
+
+**Delegated setup** (factory functions, builders, helpers called explicitly in each test) keeps each test readable while centralizing construction logic. Constructor changes only require updating the helper.
+
+**Flag when:**
+- A shared setup block creates objects that most tests don't use
+- Tests depend on external files, database state, or global variables defined elsewhere (the "Mystery Guest" smell — everything a test needs should be visible in its body or one function call away)
+- Tests assume resources exist without creating them (files, database records, environment variables)
+- Tests mutate shared state without cleanup, causing order-dependent failures
+
+### 4. Mocking Boundaries
+
+Mocks are essential for isolating units of code, but overuse turns tests into mirrors of the implementation.
+
+**The key principle:** mock at architectural boundaries, not at every function call. A test that mocks every collaborator to verify a specific call sequence will break the moment someone refactors the internals, even if the behavior is unchanged. Use stubs (which return canned data) for query-type dependencies and mocks (which verify interactions) only for side-effect-heavy commands like sending emails or writing to external systems.
+
+Different teams have different mocking philosophies — some isolate every collaborator (London/mockist style), others let real objects collaborate freely and only mock at process boundaries (Detroit/classical style). Neither is wrong, but the codebase's existing convention should be respected. Flag inconsistency within a project, not deviation from a universal rule.
+
+**Flag when:**
+- A test mocks types it doesn't own (third-party libraries, framework internals). When that library updates, the mock still passes against outdated assumptions. Recommend: thin adapter wrappers, real implementations in integration tests, or official testing utilities provided by the framework (e.g., MemoryRouter, test databases, in-memory caches).
+- Mock density is high — if a test requires 4+ mock configurations, the production code likely has too many responsibilities
+- A test verifies call counts or argument sequences on internal methods. This couples the test to how the code works rather than what it does.
+- Stubs are being verified (checking that a stub was called is testing the implementation, not the behavior)
+
+### 5. Test Smells
+
+Common patterns that signal deeper problems:
+
+| Smell | What It Looks Like | Why It Matters |
+|---|---|---|
+| **Assertion Roulette** | Multiple assertions with no failure messages | When it fails, you can't tell which assertion broke without debugging |
+| **Eager Test** | One test exercises several unrelated methods | Failures are ambiguous — which behavior actually broke? |
+| **Lazy Test** | Multiple tests call the same method with identical inputs | Redundant tests add maintenance cost without improving coverage |
+| **Sleepy Test** | Hard-coded `sleep()`/`Sys.sleep()`/`setTimeout()` delays | Flaky in CI, slow everywhere. Use polling or explicit waits. |
+| **Rotten Green** | Assertions inside `try`/`tryCatch` blocks or conditional branches | The test always passes because the assertion is never reached |
+| **Sensitive Equality** | Asserting against string representations (`toString()`, `print()` output) | Breaks on any formatting change; assert structural properties instead |
+| **Print Statement** | `print()`/`console.log()` instead of assertions | Debugging leftovers that verify nothing programmatically |
+| **Snapshot Abuse** | Snapshot tests used as a substitute for behavioral assertions | Snapshotting an entire component or output is easy to generate but verifies nothing intentionally — any change triggers a failure, and developers blindly update the snapshot. Reserve snapshots for outputs where the exact text/structure matters (error messages, CLI output, rendered documents). |
+| **Implementation Mirror** | Test computes expected values using the same logic as production code | If the test reimplements the calculation it's supposed to verify, it will always agree with the production code — including when both are wrong. Expected values should be independently derived (hardcoded from a known-good source, manually calculated, or from a reference implementation). |
+
+### 6. Naming and Readability
+
+Test names should describe behavior, not implementation. A well-named test suite reads like a specification of the feature.
+
+**Flag when:**
+- Test names reference internal method names (e.g., `test_processData_returns_true`) — these break when methods are renamed
+- Test names are generic (`test1`, `test_it_works`, `test_basic`)
+- The test name doesn't tell you what scenario is being tested or what the expected outcome is
+
+Prefer behavioral names: `test_expired_subscription_blocks_access`, `delivery_with_past_date_is_invalid`, `empty_cart_shows_zero_total`.
+
+### 7. Coverage Gaps
+
+Cross-reference the production code changes against the test suite:
+
+- Are there branches or conditions in the production code that no test exercises?
+- Are error paths tested? (Not just "does it throw" but "does it throw the right thing and clean up properly")
+- Are edge cases covered? (Empty collections, null/NA/None/undefined inputs, boundary values, concurrent access if applicable)
+- If the production code changed existing behavior, were existing tests updated to reflect the new behavior?
+
+This is where reading the production code matters. Walk through the implementation and note every decision point — each `if`, `match`, `switch`, error handler, or early return. Then check whether the test suite exercises both sides of that decision.
+
+When reviewing R tests using `testthat`, check if the `testing-r-packages` skill is available and invoke it for R-specific conventions and patterns.
+
+## Response Format
+
+```
+## Summary
+[Overall assessment: How well do these tests protect the codebase?
+Note the ratio of meaningful tests to superficial ones.]
+
+## Critical Issues (Blocking)
+[Tests that provide false confidence or will cause real problems.
+e.g., rotten green tests, mocked-out assertions, missing error-path coverage
+for critical operations.]
+
+## Required Changes
+[Design problems that weaken the test suite.
+e.g., implementation-coupled mocks, missing blast-radius assertions,
+mystery guest dependencies, assertion roulette.]
+
+## Strong Suggestions
+[Improvements to test quality and maintainability.
+e.g., better naming, fixture refactoring, additional edge cases.]
+
+## Noted
+[Minor style or convention issues. Mention once, then move on.]
+
+## Verdict
+Request Changes | Needs Discussion | Approve
+
+## Next Steps
+[Options for proceeding]
+```
+
+Use `file:line` references for every finding. Quote the specific test code that demonstrates the issue and show what better code looks like.
+
+## Next Steps
+
+At the end of the review, offer the user these options:
+
+**Discuss and address findings:** Use the AskUserQuestion tool to systematically walk through the issues. Group by severity or topic, offer resolution options, and clearly mark the recommended choice.
+
+**Fix the issues:** Offer to apply the fixes directly. Work through them in priority order — blocking issues first, then required changes, then suggestions. After each group, confirm before continuing.
+
+**Add to a pull request:** When reviewing in the context of a PR, offer to post the review as a PR comment. Include attribution: "Review assisted by the [review-testing skill](https://github.com/posit-dev/skills/blob/main/posit-dev/review-testing/SKILL.md)."
+
+If operating as a subagent, skip the next steps and output only the review findings.


### PR DESCRIPTION
Adds a new `review-testing` skill to the `posit-dev` category.

## Summary
- Adds a skill that reviews test code for quality, design, and completeness after implementing a feature or fixing a bug. Activates on prompts like "review my tests", "are these tests good enough", and "check my test quality".
- The skill evaluates tests against four key qualities (regression protection, refactoring resilience, fast feedback, maintainability) across seven review areas: assertion completeness, test structure, fixture/state management, mocking boundaries, test smells (9 named patterns), naming/readability, and coverage gaps.
- Produces severity-tiered findings (Critical Issues → Required Changes → Strong Suggestions → Noted) with `file:line` references and concrete before/after examples. Offers to discuss, fix, or post findings as a PR comment.

## Verification
Trigger the skill in Claude Code after making changes that include test files:

```
/review-testing
```

or by asking Claude to "review my tests" or "are these tests good enough" after implementing a feature. The skill will find changed test files on the branch, trace back to the production code those tests cover, and produce a structured review with concrete findings.

## review-testing (157 lines, ~2,123 tokens)

Skill description: ~80 tokens

> Review test code for quality, design, and completeness after implementing a feature or fixing a bug. Use when the user asks to "review my tests", "check my test quality", "are these tests good enough", "review testing", or after completing a feature implementation that includes tests. Also use when tests feel brittle, flaky, or superficial. Cross-references production code to find coverage gaps.

| File | Lines | ~Tokens |
|---|---:|---:|
| SKILL.md | 157 | 2,123 |