### PR TITLE
chore(shiny): update bslib skills for 0.11.0 release

### DIFF
--- a/shiny/shiny-bslib/SKILL.md
+++ b/shiny/shiny-bslib/SKILL.md
@@ -125,7 +125,7 @@ See [theming.md](references/theming.md) for detailed guidance.
 - **Tooltips** -- Hover-triggered help text
 - **Popovers** -- Click-triggered containers for secondary UI/inputs
 - **Toasts** -- Temporary notification messages
-- **Toolbars** -- Compact horizontal strips of buttons, selects, and dividers for card headers and nav bars
+- **Toolbars** -- Compact horizontal strips of buttons, selects, and dividers for card headers and footers
 
 See [accordions.md](references/accordions.md), [tooltips-popovers.md](references/tooltips-popovers.md), [toasts.md](references/toasts.md), and [toolbars.md](references/toolbars.md).
 
@@ -228,6 +228,6 @@ See [migration.md](references/migration.md) for a complete mapping of legacy pat
 - **[accordions.md](references/accordions.md)** -- Collapsible sections and sidebar organization
 - **[tooltips-popovers.md](references/tooltips-popovers.md)** -- Hover tooltips and click-triggered popovers
 - **[toasts.md](references/toasts.md)** -- Temporary notification messages
-- **[toolbars.md](references/toolbars.md)** -- Toolbar components for card headers and nav bars
+- **[toolbars.md](references/toolbars.md)** -- Toolbar components for card headers and footers
 - **[inputs.md](references/inputs.md)** -- Special bslib input widgets
 - **[best-practices.md](references/best-practices.md)** -- bslib-specific patterns and common gotchas

--- a/shiny/shiny-bslib/SKILL.md
+++ b/shiny/shiny-bslib/SKILL.md
@@ -100,6 +100,7 @@ See [navigation.md](references/navigation.md) for detailed guidance.
 - **Page-level**: `page_sidebar()` or `page_navbar(sidebar = ...)`
 - **Component-level**: `layout_sidebar()` within cards
 - Supports conditional content, dynamic open/close, accordions
+- `resizable = TRUE` by default — users can drag the edge to resize on desktop
 
 See [sidebars.md](references/sidebars.md) for detailed guidance.
 
@@ -124,8 +125,9 @@ See [theming.md](references/theming.md) for detailed guidance.
 - **Tooltips** -- Hover-triggered help text
 - **Popovers** -- Click-triggered containers for secondary UI/inputs
 - **Toasts** -- Temporary notification messages
+- **Toolbars** -- Compact horizontal strips of buttons, selects, and dividers for card headers and nav bars
 
-See [accordions.md](references/accordions.md), [tooltips-popovers.md](references/tooltips-popovers.md), and [toasts.md](references/toasts.md).
+See [accordions.md](references/accordions.md), [tooltips-popovers.md](references/tooltips-popovers.md), [toasts.md](references/toasts.md), and [toolbars.md](references/toolbars.md).
 
 ### Icons
 
@@ -226,5 +228,6 @@ See [migration.md](references/migration.md) for a complete mapping of legacy pat
 - **[accordions.md](references/accordions.md)** -- Collapsible sections and sidebar organization
 - **[tooltips-popovers.md](references/tooltips-popovers.md)** -- Hover tooltips and click-triggered popovers
 - **[toasts.md](references/toasts.md)** -- Temporary notification messages
+- **[toolbars.md](references/toolbars.md)** -- Toolbar components for card headers and nav bars
 - **[inputs.md](references/inputs.md)** -- Special bslib input widgets
 - **[best-practices.md](references/best-practices.md)** -- bslib-specific patterns and common gotchas

--- a/shiny/shiny-bslib/references/best-practices.md
+++ b/shiny/shiny-bslib/references/best-practices.md
@@ -7,6 +7,8 @@ This reference covers bslib-specific layout patterns, UX tips, and common pitfal
 - [Layout Patterns](#layout-patterns)
 - [Mobile and Responsive Design](#mobile-and-responsive-design)
 - [User Experience with bslib Components](#user-experience-with-bslib-components)
+  - [Add Contextual Help](#add-contextual-help)
+  - [Card Header Controls with Toolbars](#card-header-controls-with-toolbars)
 - [bslib Module Patterns](#bslib-module-patterns)
 - [Common Gotchas](#common-gotchas)
 
@@ -177,6 +179,55 @@ card_header(
   )
 )
 ```
+
+### Card Header Controls with Toolbars
+
+Use `toolbar()` in `card_header()` when a card needs more than one control, or when controls should look compact rather than full-width. The toolbar sits flush with the header's right edge by default.
+
+**Multiple controls on one card:**
+```r
+card(
+  card_header(
+    "Sales Trend",
+    toolbar(
+      toolbar_input_select("period", "Period",
+        choices = c("Daily", "Weekly", "Monthly"),
+        selected = "Monthly"
+      ),
+      toolbar_divider(),
+      toolbar_input_button("download", "Download",
+        icon = bsicons::bs_icon("download")
+      )
+    )
+  ),
+  plotOutput("trend_plot")
+)
+```
+
+**Adding an info icon to an input label** — wrap the label text and a `tooltip()` together in a `toolbar()`:
+```r
+selectInput(
+  "metric",
+  label = toolbar(
+    align = "left",
+    gap = "0.25rem",
+    "Metric",
+    tooltip(
+      bsicons::bs_icon("info-circle", title = "About this metric"),
+      "Revenue includes all recognized sales, net of returns and discounts."
+    )
+  ),
+  choices = c("Revenue", "Units", "Margin")
+)
+```
+
+This pattern works with any Shiny input that takes an HTML `label`. The `title` on `bs_icon()` provides accessible text for screen readers (see the Icons section in the main skill).
+
+**When to use toolbar vs. popover in card headers:**
+- Use `toolbar()` when you have **multiple controls** (select + button, or multiple buttons) — toolbars keep them properly spaced and aligned
+- Use a single `tooltip()` or `popover()` directly in `card_header()` for a **single info/settings icon** — no toolbar needed for one element
+
+See [toolbars.md](toolbars.md) for the full toolbar API.
 
 ### Show Loading States
 

--- a/shiny/shiny-bslib/references/inputs.md
+++ b/shiny/shiny-bslib/references/inputs.md
@@ -107,7 +107,7 @@ input_code_editor(
 )
 ```
 
-**Languages:** `"r"`, `"python"`, `"julia"`, `"sql"`, `"ggsql"`, `"javascript"`, `"typescript"`, `"html"`, `"css"`, `"scss"`, `"sass"`, `"json"`, `"markdown"`, `"yaml"`, `"xml"`, `"toml"`, `"ini"`, `"bash"`, `"docker"`, `"latex"`, `"cpp"`, `"rust"`, `"diff"`, `"plain"`.
+**Languages:** r, python, julia, sql, ggsql, javascript, typescript, html, css, scss, sass, json, markdown, yaml, xml, toml, ini, bash, docker, latex, cpp, rust, diff, plain.
 
 ### Configuration
 

--- a/shiny/shiny-bslib/references/inputs.md
+++ b/shiny/shiny-bslib/references/inputs.md
@@ -107,7 +107,7 @@ input_code_editor(
 )
 ```
 
-**Languages:** `"r"`, `"python"`, `"julia"`, `"sql"`, `"javascript"`, `"typescript"`, `"html"`, `"css"`, `"scss"`, `"sass"`, `"json"`, `"markdown"`, `"yaml"`, `"xml"`, `"toml"`, `"ini"`, `"bash"`, `"docker"`, `"latex"`, `"cpp"`, `"rust"`, `"diff"`, `"plain"`.
+**Languages:** `"r"`, `"python"`, `"julia"`, `"sql"`, `"ggsql"`, `"javascript"`, `"typescript"`, `"html"`, `"css"`, `"scss"`, `"sass"`, `"json"`, `"markdown"`, `"yaml"`, `"xml"`, `"toml"`, `"ini"`, `"bash"`, `"docker"`, `"latex"`, `"cpp"`, `"rust"`, `"diff"`, `"plain"`.
 
 ### Configuration
 

--- a/shiny/shiny-bslib/references/sidebars.md
+++ b/shiny/shiny-bslib/references/sidebars.md
@@ -33,7 +33,8 @@ sidebar(
 | `title` | `NULL` | Title at top |
 | `open` | `"desktop"` | Initial open/closed state — see below |
 | `position` | `"left"` | `"left"` or `"right"` |
-| `width` | `"250px"` | CSS width. Users can resize by dragging the edge |
+| `width` | `"250px"` | CSS width |
+| `resizable` | `TRUE` | Whether users can drag to resize the sidebar on desktop |
 | `id` | `NULL` | For programmatic control via `sidebar_toggle()` |
 | `bg` | | Background color (auto-contrasts `fg`) |
 | `fg` | | Foreground color |

--- a/shiny/shiny-bslib/references/toolbars.md
+++ b/shiny/shiny-bslib/references/toolbars.md
@@ -1,0 +1,260 @@
+# Toolbars in bslib
+
+Toolbars are compact horizontal strips of controls — buttons, selects, and dividers — designed to sit in card headers, sidebar headers, or navigation bars without taking up full-width space. They are distinct from full-width control strips: toolbar inputs are visually compact and integrate with the card's header styling.
+
+## Table of Contents
+
+- [Basic Usage](#basic-usage)
+- [toolbar()](#toolbar)
+- [toolbar_input_button()](#toolbar_input_button)
+- [toolbar_input_select()](#toolbar_input_select)
+- [toolbar_divider()](#toolbar_divider)
+- [Server-Side Updates](#server-side-updates)
+- [Placement Patterns](#placement-patterns)
+- [Info Icon Labels](#info-icon-labels)
+
+## Basic Usage
+
+A toolbar in a card header with a select and a button:
+
+```r
+card(
+  full_screen = TRUE,
+  card_header(
+    "Sales Trend",
+    toolbar(
+      toolbar_input_select("period", "Period",
+        choices = c("Daily", "Weekly", "Monthly"),
+        selected = "Monthly"
+      ),
+      toolbar_divider(),
+      toolbar_input_button("download", "Download",
+        icon = bsicons::bs_icon("download")
+      )
+    )
+  ),
+  plotOutput("trend_plot")
+)
+```
+
+## toolbar()
+
+```r
+toolbar(..., align = c("right", "left"), gap = NULL, width = NULL)
+```
+
+Container for toolbar elements. Defaults to right-aligned within its parent (e.g., pushed to the right end of a card header).
+
+| Parameter | Default | Description |
+|---|---|---|
+| `...` | | Toolbar elements: buttons, selects, dividers, or arbitrary HTML |
+| `align` | `"right"` | Alignment within the parent: `"right"` or `"left"` |
+| `gap` | `NULL` | CSS length unit for spacing between elements (e.g., `"0.5rem"`) |
+| `width` | `NULL` | CSS width; defaults to `100%` |
+
+## toolbar_input_button()
+
+```r
+toolbar_input_button(
+  id,
+  label,
+  icon = NULL,
+  show_label = is.null(icon),
+  tooltip = !show_label,
+  ...,
+  disabled = FALSE,
+  border = FALSE
+)
+```
+
+A compact button for use inside `toolbar()`. When an icon is provided, the label is hidden by default and shown as a tooltip instead — keeping the toolbar visually tight while remaining accessible.
+
+| Parameter | Default | Description |
+|---|---|---|
+| `id` | | Input ID. Behaves like `actionButton()` — increments on click |
+| `label` | | Button label (shown or used as tooltip text) |
+| `icon` | `NULL` | Icon element, e.g. `bsicons::bs_icon("download")` |
+| `show_label` | `is.null(icon)` | Show label text; defaults to `TRUE` when no icon |
+| `tooltip` | `!show_label` | Show label as hover tooltip when label is hidden |
+| `disabled` | `FALSE` | Prevent clicks |
+| `border` | `FALSE` | Show a border around the button |
+
+**Reading the value:** `input$id` increments like `actionButton()`. Use `observeEvent(input$id, ...)`.
+
+**Accessibility:** When `show_label = FALSE`, the label is still used as tooltip text (`tooltip = TRUE` by default) so screen reader and keyboard users can identify the button.
+
+## toolbar_input_select()
+
+```r
+toolbar_input_select(
+  id,
+  label,
+  choices,
+  ...,
+  selected = NULL,
+  icon = NULL,
+  show_label = FALSE,
+  tooltip = !show_label
+)
+```
+
+A compact select input for use inside `toolbar()`. The label is hidden by default (`show_label = FALSE`) and shown as a tooltip, keeping the toolbar uncluttered when context makes the purpose obvious.
+
+| Parameter | Default | Description |
+|---|---|---|
+| `id` | | Input ID. `input$id` returns the selected value |
+| `label` | | Label (used as tooltip when `show_label = FALSE`) |
+| `choices` | | Character vector or named list of choices |
+| `selected` | `NULL` | Initially selected value (defaults to first choice) |
+| `icon` | `NULL` | Optional icon shown alongside the select |
+| `show_label` | `FALSE` | Show label text inline |
+| `tooltip` | `!show_label` | Show label as tooltip when hidden |
+
+**Reading the value:** `input$id` returns the selected value as a string.
+
+## toolbar_divider()
+
+```r
+toolbar_divider(..., width = NULL, gap = NULL)
+```
+
+A thin vertical rule for visually grouping toolbar elements.
+
+| Parameter | Default | Description |
+|---|---|---|
+| `width` | `"2px"` | CSS width of the divider line |
+| `gap` | `"1rem"` | CSS spacing on either side of the divider |
+
+## Server-Side Updates
+
+### update_toolbar_input_button()
+
+```r
+update_toolbar_input_button(
+  id,
+  label = NULL,
+  show_label = NULL,
+  icon = NULL,
+  disabled = NULL,
+  session = get_current_session()
+)
+```
+
+Update button appearance or state from the server. Pass only the parameters you want to change; `NULL` leaves them unchanged.
+
+**Example — disable while processing:**
+```r
+observeEvent(input$run, {
+  update_toolbar_input_button("run", disabled = TRUE)
+  result <- do_analysis()
+  output$result <- renderTable(result)
+  update_toolbar_input_button("run", disabled = FALSE)
+})
+```
+
+### update_toolbar_input_select()
+
+```r
+update_toolbar_input_select(
+  id,
+  label = NULL,
+  show_label = NULL,
+  choices = NULL,
+  selected = NULL,
+  icon = NULL,
+  session = get_current_session()
+)
+```
+
+Update select choices, selection, or label from the server.
+
+**Example — cascading selects:**
+```r
+observeEvent(input$region, {
+  update_toolbar_input_select("store",
+    choices = stores_for_region(input$region)
+  )
+})
+```
+
+## Placement Patterns
+
+### Card Header (most common)
+
+```r
+card(
+  card_header(
+    "Monthly Revenue",
+    toolbar(
+      toolbar_input_select("currency", "Currency",
+        choices = c("USD", "EUR", "GBP")
+      ),
+      toolbar_input_button("export", "Export",
+        icon = bsicons::bs_icon("box-arrow-up")
+      )
+    )
+  ),
+  plotOutput("revenue_plot")
+)
+```
+
+### Navset Card with Shared Controls
+
+Place a toolbar in the `title` of `navset_card_underline()` to share controls across all tabs:
+
+```r
+navset_card_underline(
+  title = tagList(
+    "Analysis",
+    toolbar(
+      toolbar_input_select("metric", "Metric",
+        choices = c("Revenue", "Units", "Margin")
+      )
+    )
+  ),
+  full_screen = TRUE,
+  nav_panel("By Region", plotOutput("region_plot")),
+  nav_panel("By Product", plotOutput("product_plot"))
+)
+```
+
+### Sidebar Header
+
+```r
+sidebar(
+  title = tagList(
+    "Filters",
+    toolbar(
+      align = "right",
+      toolbar_input_button("reset", "Reset",
+        icon = bsicons::bs_icon("arrow-counterclockwise")
+      )
+    )
+  ),
+  selectInput("species", "Species", ...)
+)
+```
+
+## Info Icon Labels
+
+A toolbar is the cleanest way to add a help tooltip to an input label. Wrap the label text and an info icon together in a `toolbar()` as the `label` argument:
+
+```r
+selectInput(
+  "metric",
+  label = toolbar(
+    align = "left",
+    gap = "0.25rem",
+    "Metric",
+    tooltip(
+      bsicons::bs_icon("info-circle", title = "About this metric"),
+      "Revenue includes all recognized sales net of returns and discounts."
+    )
+  ),
+  choices = c("Revenue", "Units", "Margin")
+)
+```
+
+This works with any Shiny input that takes an HTML `label` argument. The `title` on `bs_icon()` provides accessible text for screen readers — see the main skill's Icons section for accessibility guidance on icon-only triggers.
+
+For a simpler single-icon trigger without a full toolbar, use `tooltip()` or `popover()` directly in `card_header()` instead (see [best-practices.md](best-practices.md)).

--- a/shiny/shiny-bslib/references/toolbars.md
+++ b/shiny/shiny-bslib/references/toolbars.md
@@ -1,6 +1,6 @@
 # Toolbars in bslib
 
-Toolbars are compact horizontal strips of controls — buttons, selects, and dividers — designed to sit in card headers, sidebar headers, or navigation bars without taking up full-width space. They are distinct from full-width control strips: toolbar inputs are visually compact and integrate with the card's header styling.
+Toolbars are compact horizontal strips of controls — buttons, selects, and dividers — designed for card headers and footers. Toolbar inputs are visually compact and integrate with the card's header/footer styling, unlike full-width sidebar controls.
 
 ## Table of Contents
 
@@ -142,7 +142,19 @@ update_toolbar_input_button(
 
 Update button appearance or state from the server. Pass only the parameters you want to change; `NULL` leaves them unchanged.
 
-**Example — conditionally disable based on reactive state:**
+**Example — toggle icon on click:**
+```r
+chart_type <- reactiveVal("bar")
+observeEvent(input$toggle_type, {
+  new_type <- if (chart_type() == "bar") "line" else "bar"
+  chart_type(new_type)
+  update_toolbar_input_button("toggle_type",
+    icon = bsicons::bs_icon(if (new_type == "bar") "bar-chart" else "graph-up")
+  )
+})
+```
+
+**Example — conditionally disable:**
 ```r
 observe({
   update_toolbar_input_button("export",
@@ -177,26 +189,6 @@ observeEvent(input$region, {
 ```
 
 ## Placement Patterns
-
-### Card Header (most common)
-
-```r
-card(
-  card_header(
-    "Monthly Revenue",
-    toolbar(
-      toolbar_input_select("currency", "Currency",
-        choices = c("USD", "EUR", "GBP")
-      ),
-      toolbar_input_button("export", "Export",
-        icon = bsicons::bs_icon("box-arrow-up")
-      )
-    )
-  ),
-  plotOutput("revenue_plot")
-)
-```
-
 
 ### Card Footer
 
@@ -242,5 +234,3 @@ selectInput(
 ```
 
 This works with any Shiny input that takes an HTML `label` argument. The `title` on `bs_icon()` provides accessible text for screen readers — see the main skill's Icons section for accessibility guidance on icon-only triggers.
-
-For a simpler single-icon trigger without a full toolbar, use `tooltip()` or `popover()` directly in `card_header()` instead (see [best-practices.md](best-practices.md)).

--- a/shiny/shiny-bslib/references/toolbars.md
+++ b/shiny/shiny-bslib/references/toolbars.md
@@ -198,44 +198,6 @@ card(
 )
 ```
 
-### Navset Card with Shared Controls
-
-Use `card_header()` via the `header` argument to share controls across all tabs:
-
-```r
-navset_card_underline(
-  header = card_header(
-    "Analysis",
-    toolbar(
-      toolbar_input_select("metric", "Metric",
-        choices = c("Revenue", "Units", "Margin")
-      )
-    )
-  ),
-  full_screen = TRUE,
-  nav_panel("By Region", plotOutput("region_plot")),
-  nav_panel("By Product", plotOutput("product_plot"))
-)
-```
-
-### Sidebar with a Reset Button
-
-Place a toolbar directly inside the sidebar when you want a compact action button alongside the sidebar's controls:
-
-```r
-sidebar(
-  title = "Filters",
-  toolbar(
-    align = "right",
-    toolbar_input_button("reset", "Reset filters",
-      icon = bsicons::bs_icon("arrow-counterclockwise")
-    )
-  ),
-  selectInput("species", "Species",
-    choices = c("Adelie", "Chinstrap", "Gentoo")
-  )
-)
-```
 
 ## Info Icon Labels
 

--- a/shiny/shiny-bslib/references/toolbars.md
+++ b/shiny/shiny-bslib/references/toolbars.md
@@ -200,11 +200,11 @@ card(
 
 ### Navset Card with Shared Controls
 
-Place a toolbar in the `title` of `navset_card_underline()` to share controls across all tabs:
+Use `card_header()` via the `header` argument to share controls across all tabs:
 
 ```r
 navset_card_underline(
-  title = tagList(
+  header = card_header(
     "Analysis",
     toolbar(
       toolbar_input_select("metric", "Metric",
@@ -218,20 +218,22 @@ navset_card_underline(
 )
 ```
 
-### Sidebar Header
+### Sidebar with a Reset Button
+
+Place a toolbar directly inside the sidebar when you want a compact action button alongside the sidebar's controls:
 
 ```r
 sidebar(
-  title = tagList(
-    "Filters",
-    toolbar(
-      align = "right",
-      toolbar_input_button("reset", "Reset",
-        icon = bsicons::bs_icon("arrow-counterclockwise")
-      )
+  title = "Filters",
+  toolbar(
+    align = "right",
+    toolbar_input_button("reset", "Reset filters",
+      icon = bsicons::bs_icon("arrow-counterclockwise")
     )
   ),
-  selectInput("species", "Species", ...)
+  selectInput("species", "Species",
+    choices = c("Adelie", "Chinstrap", "Gentoo")
+  )
 )
 ```
 

--- a/shiny/shiny-bslib/references/toolbars.md
+++ b/shiny/shiny-bslib/references/toolbars.md
@@ -142,13 +142,12 @@ update_toolbar_input_button(
 
 Update button appearance or state from the server. Pass only the parameters you want to change; `NULL` leaves them unchanged.
 
-**Example — disable while processing:**
+**Example — conditionally disable based on reactive state:**
 ```r
-observeEvent(input$run, {
-  update_toolbar_input_button("run", disabled = TRUE)
-  result <- do_analysis()
-  output$result <- renderTable(result)
-  update_toolbar_input_button("run", disabled = FALSE)
+observe({
+  update_toolbar_input_button("export",
+    disabled = nrow(filtered_data()) == 0
+  )
 })
 ```
 

--- a/shiny/shiny-bslib/references/toolbars.md
+++ b/shiny/shiny-bslib/references/toolbars.md
@@ -199,6 +199,29 @@ card(
 ```
 
 
+### Card Footer
+
+```r
+card(
+  card_header("Plot"),
+  plotOutput("plot"),
+  card_footer(
+    toolbar(
+      toolbar_input_button("save", "Save",
+        icon = bsicons::bs_icon("floppy")
+      ),
+      toolbar_input_button("share", "Share",
+        icon = bsicons::bs_icon("share")
+      ),
+      toolbar_divider(),
+      toolbar_input_button("fullscreen", "Expand",
+        icon = bsicons::bs_icon("arrows-fullscreen")
+      )
+    )
+  )
+)
+```
+
 ## Info Icon Labels
 
 A toolbar is the cleanest way to add a help tooltip to an input label. Wrap the label text and an info icon together in a `toolbar()` as the `label` argument:


### PR DESCRIPTION
## Summary

Updates the `shiny-bslib` skill for the bslib 0.11.0 release (May 2026).

## Changes

### New
- `references/toolbars.md` — API reference for the new toolbar component suite (`toolbar()`, `toolbar_input_button()`, `toolbar_input_select()`, `toolbar_divider()`, and server-side update functions); covers card header and footer placement, info-icon input labels, and verified examples

### Updated
- `SKILL.md` — added Toolbars to UI Components section; noted `resizable = TRUE` default on sidebars; added `toolbars.md` to reference list
- `references/sidebars.md` — added `resizable` parameter to the parameters table
- `references/inputs.md` — added `"ggsql"` to `input_code_editor()` language list
- `references/best-practices.md` — added "Card Header Controls with Toolbars" subsection covering multi-control card headers, info-icon input labels, and guidance on toolbar vs. bare tooltip/popover

## bslib 0.11.0 highlights covered
- Toolbar component suite (new)
- Resizable sidebars (`resizable` arg, defaults `TRUE`)
- `input_code_editor()` ggsql language support