### PR TITLE
feat(posit-dev): add new-work skill for todo tracking

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,6 +18,8 @@
         "./posit-dev/critical-code-reviewer",
         "./posit-dev/describe-design",
         "./posit-dev/implement",
+        "./posit-dev/improve-prose",
+        "./posit-dev/new-work",
         "./posit-dev/review-testing",
         "./posit-dev/working-on"
       ]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ General-purpose developer skills useful across any language, project type, or co
 
 - **[critical-code-reviewer](./posit-dev/critical-code-reviewer/)** - Conduct rigorous, adversarial code reviews identifying security holes, lazy patterns, edge case failures, and bad practices across Python, R, JavaScript/TypeScript, SQL, and front-end code
 - **[describe-design](./posit-dev/describe-design/)** - Research a codebase and create architectural documentation describing how features or systems work, with Mermaid diagrams and stable code references suitable for humans and AI agents
+- **[new-work](./posit-dev/new-work/)** - Create a todo tracking document for a new feature, bug, or task; keeps it updated with decisions, plans, and progress for the rest of the session
 - **[review-testing](./posit-dev/review-testing/)** - Review test code for quality, design, and completeness after implementing a feature or fixing a bug, covering assertion completeness, mocking boundaries, fixture design, test smells, and coverage gaps
+- **[working-on](./posit-dev/working-on/)** - Set an existing tracking document as the source of truth for the current session, keeping it updated with decisions and progress
 
 
 ### GitHub

--- a/posit-dev/README.md
+++ b/posit-dev/README.md
@@ -5,10 +5,33 @@ General-purpose developer skills useful across any language, project type, or co
 ## Skills
 
 - **[critical-code-reviewer](./critical-code-reviewer/)** - Rigorous, adversarial code review across Python, R, JavaScript/TypeScript, SQL, and front-end code
-- **[review-testing](./posit-dev/review-testing/)** - Review test code for quality, design, and completeness after implementing a feature or fixing a bug, covering assertion completeness, mocking boundaries, fixture design, test smells, and coverage gaps
+- **[review-testing](./review-testing/)** - Review test code for quality, design, and completeness after implementing a feature or fixing a bug, covering assertion completeness, mocking boundaries, fixture design, test smells, and coverage gaps
 - **[describe-design](./describe-design/)** - Research a codebase and create architectural documentation with Mermaid diagrams
 - **[implement](./implement/)** - Orchestrates implementation of a plan file by delegating work to subagents in parallel
-- **[working-on](./working-on/)** - Sets a tracking document as the source of truth for the current task, keeping it updated with decisions and progress
+- **[new-work](./new-work/)** - Create a todo tracking document for a new feature, bug, or task; keeps it updated with decisions, plans, and progress for the rest of the session
+- **[working-on](./working-on/)** - Sets an existing tracking document as the source of truth for the current session, keeping it updated with decisions and progress
+
+## Work Tracking Lifecycle
+
+These three skills provide a lightweight way to bridge sessions: a todo document holds enough context that any fresh session can pick up exactly where the last one left off, without re-explaining the problem or re-deriving decisions.
+
+Three skills work together to track a piece of work from start to finish:
+
+1. **`/new-work`** — Start here. Creates a todo document in `_dev/todos/pending/` and keeps it updated for the rest of the session. Write your plan here; it becomes the persistent record.
+
+2. **`/working-on <path>`** — Resume here in a new session. Point it at an existing todo document and it picks up the same live-update behavior: decisions, plans, and commits all flow back into the file.
+
+3. **`/implement <path>`** — Execute here. Takes a plan file (which can be the todo document itself, or a separate plan written into it) and orchestrates implementation by delegating to parallel subagents.
+
+A typical flow:
+
+```
+/new-work          → gather context and plan in the todo document
+   --- new session ---
+/implement <todo>  → execute the plan, update the document
+   --- new session ---
+/working-on <todo> → continue tracking progress
+```
 
 ## Contributing
 

--- a/posit-dev/new-work/SKILL.md
+++ b/posit-dev/new-work/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: new-work
+description: "Create and manage todo tracking documents for features, bugs, and multi-step tasks. Use when starting new work that benefits from a persistent record of decisions, progress, and context."
+disable-model-invocation: true
+metadata:
+  author: Garrick Aden-Buie (@gadenbuie)
+  version: "1.0"
+license: MIT
+---
+
+# New Work
+
+Todo notes track work items as markdown files with YAML front matter capturing status, context, and progress.
+
+## Storage Location
+
+Use `_dev/todos/` if it exists in the repository root; otherwise ask the user where to store todo notes before creating anything. It contains two subdirectories: `pending/` (active) and `done/` (finished).
+
+## File Naming
+
+`YYYY-MM-DD_short-kebab-slug.md`, e.g. `2026-02-18_add-oauth-support.md`.
+
+## File Contents
+
+YAML front matter plus a markdown body. Only `status` is required.
+
+```markdown
+---
+status: pending   # pending | in progress | review | blocked | done
+issue: https://github.com/org/repo/issues/123   # optional
+pr: https://github.com/org/repo/pull/456        # optional
+---
+
+# Title
+
+Overview of what this is about and why it matters.
+
+## Key Files
+
+- `src/relevant-file.ts` — what it does
+- `src/other-file.ts:functionName()` — why it matters
+
+## Work Items
+
+- [ ] First thing to do
+- [ ] Second thing to do
+
+## Design Decisions
+
+Context, constraints, or choices worth capturing.
+
+## Decision Log
+
+<!--
+### YYYY-MM-DD — Short Decision Title
+**Decision:** What was decided?
+**Rationale:** Why?
+-->
+```
+
+## Lifecycle
+
+- **Create:** make `pending/` if needed, create the date-prefixed file with `status: pending`, and write enough context to resume later.
+- **In progress:** update `status`; add `issue`/`pr` links when they exist; check off Work Items (`- [ ]` → `- [x]`); record significant decisions in the Decision Log.
+- **Complete:** set `status: done` and `mv` the file from `pending/` to `done/`.
+
+## Keeping the Document Current
+
+Treat the todo as a living record for the rest of the session. Update it after any decision, newly discovered problem or requirement, issue raised/resolved, significant implementation work, or commit. When in doubt, update it.
+
+When you form a plan — whether in response to a user request or on your own initiative — write it to the todo document rather than presenting it only in chat. The document is the persistent record; the chat is not.
+
+To resume in a future session, use `/working-on <path-to-todo>` — same live-document behavior without re-creating the file.

--- a/posit-dev/working-on/SKILL.md
+++ b/posit-dev/working-on/SKILL.md
@@ -6,7 +6,7 @@ arguments: [path]
 argument-hint: "[path-to-tracking-doc] [additional instructions]"
 metadata:
   author: Garrick Aden-Buie (@gadenbuie)
-  version: "1.0"
+  version: "1.1"
 license: MIT
 ---
 
@@ -27,6 +27,7 @@ Once activated, treat the tracking document as a living record. Update it after:
 - Any significant implementation work is completed
 - A key part of a conversation with the user that would be useful to recall later
 - Any time you commit files — a commit is a strong signal that the tracking document should also be reviewed and updated
+- Any plan you form — write it to the document rather than presenting it only in chat; the document is the persistent record
 
 If in doubt, update the document. It is better to over-document than to lose context.
 


### PR DESCRIPTION
## Summary

Adds `/new-work`, a skill for creating and maintaining lightweight todo tracking documents in `_dev/todos/`. Each document captures status, context, plans, key files, and a decision log — enough that any fresh Claude Code session can resume work without re-explaining the problem.

The skill keeps the document updated throughout the session (decisions, commits, new discoveries) and points to `/working-on` for resuming in future sessions.

Also updates `/working-on` (v1.1) to write plans into the tracking document rather than only in chat.

Adds a Work Tracking Lifecycle section to `posit-dev/README.md` explaining how `/new-work`, `/working-on`, and `/implement` compose into a session-bridging workflow.

## Verification

Install the posit-dev plugin and start a new session in any repo:

```
/new-work
```

Claude should prompt for a todo location (or use `_dev/todos/` if it exists), create a date-prefixed markdown file in `pending/`, and keep it updated as work proceeds. At the start of a new session, `/working-on <path>` resumes tracking.