### PR TITLE
Use python-frontmatter to avoid vulnerable PyYAML pin

### DIFF
--- a/count-skill-tokens.py
+++ b/count-skill-tokens.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 # /// script
 # dependencies = [
-#   "frontmatter",
+#   "python-frontmatter",
 #   "tiktoken",
 # ]
 # ///
@@ -20,7 +20,7 @@ import sys
 from pathlib import Path
 
 import tiktoken
-from frontmatter import Frontmatter
+import frontmatter
 
 
 def count_tokens(text: str, encoding: tiktoken.Encoding) -> int:
@@ -42,8 +42,8 @@ def main() -> None:
     enc = tiktoken.get_encoding("cl100k_base")
 
     # Parse SKILL.md frontmatter
-    parsed = Frontmatter.read_file(str(skill_md))
-    attrs = parsed["attributes"]
+    parsed = frontmatter.load(str(skill_md))
+    attrs = parsed.metadata
     skill_name = attrs.get("name", skill_dir.name)
     skill_description = attrs.get("description", "")
 


### PR DESCRIPTION
count-skill-tokens.py depends on frontmatter, which pins PyYAML==5.1 and parses YAML using FullLoader. This combination is affected by CVE-2020-1747 and CVE-2020-14343, allowing arbitrary code execution when parsing untrusted YAML.

Replace frontmatter with python-frontmatter, which uses SafeLoader by default and does not impose the obsolete PyYAML pin. Update the script to use frontmatter.load() and Post.metadata.

Validation:

* Successfully parsed metadata and tokenized descriptions for all 26 skills.
* Confirmed identical token-counter output before and after the change for r-lib/cli.
* git diff --check passes.